### PR TITLE
Added support for unoptimized prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ module.exports = {
 
 5. In the development mode, the original image will be served as the optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser
 
+6. As with the `<Image/>` component You may output original images with no optimization applied with the `unoptimized` prop.
+
 ## Live example
 
 You can see a live example of the use of this library at [reactapp.dev/next-image-export-optimizer](https://reactapp.dev/next-image-export-optimizer)

--- a/example/localTestComponent/ExportedImage.tsx
+++ b/example/localTestComponent/ExportedImage.tsx
@@ -63,7 +63,7 @@ const fallbackLoader = ({ src }: { src: string }) => {
 };
 
 export interface ExportedImageProps
-  extends Omit<ImageProps, "src" | "loader" | "onError" | "unoptimized"> {
+  extends Omit<ImageProps, "src" | "loader" | "onError"> {
   src: string;
 }
 
@@ -80,6 +80,7 @@ function ExportedImage({
   objectFit,
   objectPosition,
   onLoadingComplete,
+  unoptimized,
   placeholder = process.env.generateAndUseBlurImages === true
     ? "blur"
     : "empty",
@@ -88,13 +89,17 @@ function ExportedImage({
 }: ExportedImageProps) {
   const [imageError, setImageError] = useState(false);
   const automaticallyCalculatedBlurDataURL = useMemo(() => {
+    if (unoptimized === true) {
+      // return the src image when unoptimized
+      return src;
+    }
     if (blurDataURL) {
       // use the user provided blurDataURL if present
       return blurDataURL;
     }
     // otherwise use the generated image of 10px width as a blurDataURL
     return generateImageURL(src, 10);
-  }, [blurDataURL, src]);
+  }, [blurDataURL, src, unoptimized]);
 
   return (
     <Image
@@ -111,7 +116,8 @@ function ExportedImage({
       {...(objectPosition && { objectPosition })}
       {...(onLoadingComplete && { onLoadingComplete })}
       {...(placeholder && { placeholder })}
-      loader={imageError ? fallbackLoader : optimizedLoader}
+      {...(unoptimized && { unoptimized })}
+      loader={imageError || unoptimized === true ? fallbackLoader : optimizedLoader}
       blurDataURL={automaticallyCalculatedBlurDataURL}
       src={src}
       onError={() => {

--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -16,6 +16,7 @@ export default function Home() {
 
       <main className={styles.main}>
         <h1 className={styles.title}>Next-Image-Export-Optimizer</h1>
+        <h2>Optimized example</h2>
         <div
           style={{
             position: "relative",
@@ -31,6 +32,26 @@ export default function Home() {
             objectFit="cover"
             priority={true}
             alt={"test_image"}
+          />
+        </div>
+
+        <h2>Unoptimized example</h2>
+        <div
+          style={{
+            position: "relative",
+            width: "50%",
+            height: "200px",
+            marginBottom: "3rem",
+          }}
+        >
+          <ExportedImage
+            src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+            layout="fill"
+            id="test_image_unoptimized"
+            objectFit="cover"
+            priority={true}
+            alt={"test_image_unoptimized"}
+            unoptimized={true}
           />
         </div>
         <ExportedImage

--- a/src/ExportedImage.tsx
+++ b/src/ExportedImage.tsx
@@ -63,7 +63,7 @@ const fallbackLoader = ({ src }: { src: string }) => {
 };
 
 export interface ExportedImageProps
-  extends Omit<ImageProps, "src" | "loader" | "onError" | "unoptimized"> {
+  extends Omit<ImageProps, "src" | "loader" | "onError"> {
   src: string;
 }
 
@@ -80,6 +80,7 @@ function ExportedImage({
   objectFit,
   objectPosition,
   onLoadingComplete,
+  unoptimized,
   placeholder = process.env.generateAndUseBlurImages === true
     ? "blur"
     : "empty",
@@ -88,13 +89,17 @@ function ExportedImage({
 }: ExportedImageProps) {
   const [imageError, setImageError] = useState(false);
   const automaticallyCalculatedBlurDataURL = useMemo(() => {
+    if (unoptimized === true) {
+      // return the src image when unoptimized
+      return src;
+    }
     if (blurDataURL) {
       // use the user provided blurDataURL if present
       return blurDataURL;
     }
     // otherwise use the generated image of 10px width as a blurDataURL
     return generateImageURL(src, 10);
-  }, [blurDataURL, src]);
+  }, [blurDataURL, src, unoptimized]);
 
   return (
     <Image
@@ -111,7 +116,8 @@ function ExportedImage({
       {...(objectPosition && { objectPosition })}
       {...(onLoadingComplete && { onLoadingComplete })}
       {...(placeholder && { placeholder })}
-      loader={imageError ? fallbackLoader : optimizedLoader}
+      {...(unoptimized && { unoptimized })}
+      loader={imageError || unoptimized === true ? fallbackLoader : optimizedLoader}
       blurDataURL={automaticallyCalculatedBlurDataURL}
       src={src}
       onError={() => {


### PR DESCRIPTION
This PR adds support for the `unoptimized` prop so images may be exported maintaining original source references with no image optimization applied.

**Why?**
It allows us to use the `ExportedImage` component for both local, optimized images as well as CDN/hosted images which do not support optimization.