### PR TITLE
Support future image

### DIFF
--- a/.github/workflows/check-compare-localTestComponent-src.yml
+++ b/.github/workflows/check-compare-localTestComponent-src.yml
@@ -6,14 +6,25 @@ on:
     branches: ["master"]
 
 jobs:
-  test_something:
+  test_legacy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: LouisBrunner/diff-action@v0.1.0
-      with:
-        old: src/ExportedImage.tsx
-        new: example/localTestComponent/ExportedImage.tsx
-        mode: addition
-        tolerance: same
-        output: out.txt
+      - uses: actions/checkout@v1
+      - uses: LouisBrunner/diff-action@v0.1.0
+        with:
+          old: src/ExportedImage.tsx
+          new: example/localTestComponent/ExportedImage.tsx
+          mode: addition
+          tolerance: same
+          output: out.txt
+  test_future:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: LouisBrunner/diff-action@v0.1.0
+        with:
+          old: src/Future/ExportedImage.tsx
+          new: example/localTestComponent/ExportedImageFuture.tsx
+          mode: addition
+          tolerance: same
+          output: out.txt

--- a/.github/workflows/check-compare-localTestComponent-src.yml
+++ b/.github/workflows/check-compare-localTestComponent-src.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: LouisBrunner/diff-action@v0.1.0
         with:
-          old: src/Future/ExportedImage.tsx
+          old: src/future/ExportedImage.tsx
           new: example/localTestComponent/ExportedImageFuture.tsx
           mode: addition
           tolerance: same

--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ module.exports = {
    **Usage of the WEBP format:**
    If you do not want to use the WEBP format, set the `nextImageExportOptimizer_storePicturesInWEBP` environment variable to `false` and set the `useWebp` prop from the **\<ExportedImage />** component to `false`.
 
+8. Using the next/future/image component is now supported: (More information: https://nextjs.org/docs/api-reference/next/image)
+
+   ```javascript
+   import ExportedImage from "next-image-export-optimizer/future/ExportedImage";
+
+   import testPictureStatic from "PATH_TO_IMAGE/test_static.jpg";
+
+   <ExportedImage
+     src={testPictureStatic}
+     alt="Static Image"
+     useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+   />;
+   ```
+
 ## Live example
 
 You can see a live example of the use of this library at [reactapp.dev/next-image-export-optimizer](https://reactapp.dev/next-image-export-optimizer)

--- a/example/localTestComponent/ExportedImage.tsx
+++ b/example/localTestComponent/ExportedImage.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
 import React, { useMemo, useState } from "react";
-import { ImageProps, StaticImageData } from "next/image";
+import Image, { ImageProps, StaticImageData } from "next/image";
 
 const splitFilePath = ({ filePath }: { filePath: string }) => {
   const filenameWithExtension =

--- a/example/localTestComponent/ExportedImage.tsx
+++ b/example/localTestComponent/ExportedImage.tsx
@@ -77,7 +77,8 @@ const fallbackLoader = ({ src }: { src: string | StaticImageData }) => {
   return _src;
 };
 
-export interface ExportedImageProps extends Omit<ImageProps, "src" | "loader"> {
+export interface ExportedImageProps
+  extends Omit<ImageProps, "src" | "loader" | "quality"> {
   src: string | StaticImageData;
   useWebp?: boolean;
 }
@@ -89,7 +90,6 @@ function ExportedImage({
   lazyRoot = null,
   lazyBoundary = "200px",
   className,
-  quality,
   width,
   height,
   objectFit,
@@ -130,7 +130,6 @@ function ExportedImage({
       {...(lazyRoot && { lazyRoot })}
       {...(lazyBoundary && { lazyBoundary })}
       {...(className && { className })}
-      {...(quality && { quality })}
       {...(objectFit && { objectFit })}
       {...(objectPosition && { objectPosition })}
       {...(onLoadingComplete && { onLoadingComplete })}

--- a/example/localTestComponent/ExportedImageFuture.tsx
+++ b/example/localTestComponent/ExportedImageFuture.tsx
@@ -1,6 +1,5 @@
-import Image from "next/future/image";
 import React, { useMemo, useState } from "react";
-import { ImageProps, StaticImageData } from "next/future/image";
+import Image, { ImageProps, StaticImageData } from "next/future/image";
 
 const splitFilePath = ({ filePath }: { filePath: string }) => {
   const filenameWithExtension =

--- a/example/localTestComponent/ExportedImageFuture.tsx
+++ b/example/localTestComponent/ExportedImageFuture.tsx
@@ -1,6 +1,6 @@
-import Image from "next/image";
+import Image from "next/future/image";
 import React, { useMemo, useState } from "react";
-import { ImageProps, StaticImageData } from "next/image";
+import { ImageProps, StaticImageData } from "next/future/image";
 
 const splitFilePath = ({ filePath }: { filePath: string }) => {
   const filenameWithExtension =
@@ -87,18 +87,15 @@ function ExportedImage({
   src,
   priority = false,
   loading,
-  lazyRoot = null,
-  lazyBoundary = "200px",
   className,
   width,
   height,
-  objectFit,
-  objectPosition,
   useWebp = true,
   onLoadingComplete,
   unoptimized,
   placeholder = "blur",
   blurDataURL,
+  style,
   onError,
   ...rest
 }: ExportedImageProps) {
@@ -119,7 +116,25 @@ function ExportedImage({
     return generateImageURL(_src, 10, useWebp);
   }, [blurDataURL, src, unoptimized]);
 
-  return (
+  const [blurComplete, setBlurComplete] = useState(false);
+
+  // Currently, we have to handle the blurDataURL ourselves as the new Image component
+  // is expecting a base64 encoded string, but the generated blurDataURL is a normal URL
+  const blurStyle =
+    placeholder === "blur" &&
+    automaticallyCalculatedBlurDataURL &&
+    automaticallyCalculatedBlurDataURL.startsWith("/") &&
+    !blurComplete
+      ? {
+          backgroundSize: style?.objectFit || "cover",
+          backgroundPosition: style?.objectPosition || "50% 50%",
+          backgroundRepeat: "no-repeat",
+          backgroundImage: `url(${automaticallyCalculatedBlurDataURL})`,
+          filter: "url(#sharpBlur)",
+        }
+      : undefined;
+
+  const ImageElement = (
     <Image
       {...rest}
       {...(typeof src === "object" && src.width && { width: src.width })}
@@ -127,16 +142,14 @@ function ExportedImage({
       {...(width && { width })}
       {...(height && { height })}
       {...(loading && { loading })}
-      {...(lazyRoot && { lazyRoot })}
-      {...(lazyBoundary && { lazyBoundary })}
       {...(className && { className })}
-      {...(objectFit && { objectFit })}
-      {...(objectPosition && { objectPosition })}
       {...(onLoadingComplete && { onLoadingComplete })}
-      {...(placeholder && { placeholder })}
+      // if the blurStyle is not "empty", then we take care of the blur behavior ourselves
+      {...(placeholder && { placeholder: blurStyle ? "empty" : placeholder })}
       {...(unoptimized && { unoptimized })}
       {...(priority && { priority })}
       {...(imageError && { unoptimized: true })}
+      style={{ ...style, ...blurStyle }}
       loader={
         imageError || unoptimized === true
           ? fallbackLoader
@@ -145,6 +158,7 @@ function ExportedImage({
       blurDataURL={automaticallyCalculatedBlurDataURL}
       onError={(error) => {
         setImageError(true);
+        setBlurComplete(true);
         // execute the onError function if provided
         onError && onError(error);
       }}
@@ -155,11 +169,72 @@ function ExportedImage({
           // Broken image, fall back to unoptimized (meaning the original image src)
           setImageError(true);
         }
+        setBlurComplete(true);
+
         // execute the onLoadingComplete callback if present
         onLoadingComplete && onLoadingComplete(result);
       }}
       src={typeof src === "object" ? src.src : src}
     />
+  );
+
+  // When we present a placeholder, we add a svg filter to the image and remove it after either
+  // the image is loaded or an error occurred
+  return blurStyle ? (
+    <>
+      {/* In case javascript is disabled, we show a fallback without blurry placeholder */}
+      <noscript>
+        <Image
+          {...rest}
+          {...(typeof src === "object" && src.width && { width: src.width })}
+          {...(typeof src === "object" && src.height && { height: src.height })}
+          {...(width && { width })}
+          {...(height && { height })}
+          {...(loading && { loading })}
+          {...(className && { className })}
+          placeholder="empty"
+          {...(unoptimized && { unoptimized })}
+          {...(priority && { priority })}
+          style={style}
+          loader={
+            imageError || unoptimized === true
+              ? fallbackLoader
+              : (e) => optimizedLoader({ src, width: e.width, useWebp })
+          }
+          src={typeof src === "object" ? src.src : src}
+        />
+      </noscript>
+      {ImageElement}
+      <svg
+        style={{
+          border: 0,
+          clip: "rect(0 0 0 0)",
+          height: "1px",
+          margin: "-1px",
+          overflow: "hidden",
+          padding: 0,
+          position: "absolute",
+          width: "1px",
+          display: "none",
+        }}
+      >
+        <filter id="sharpBlur">
+          <feGaussianBlur
+            stdDeviation="20"
+            colorInterpolationFilters="sRGB"
+          ></feGaussianBlur>
+          <feColorMatrix
+            type="matrix"
+            colorInterpolationFilters="sRGB"
+            values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0"
+          ></feColorMatrix>
+
+          <feComposite in2="SourceGraphic" operator="in"></feComposite>
+        </filter>
+      </svg>
+    </>
+  ) : (
+    ImageElement
   );
 }
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "example",
       "dependencies": {
-        "next": "^12.3.2-canary.28",
-        "next-image-export-optimizer": "^0.16.1-beta-1",
+        "next": "^12.3.1",
+        "next-image-export-optimizer": "^0.16.1-beta-2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -17,14 +17,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.28.tgz",
-      "integrity": "sha512-q1ueMCKvS27IBaUZobMkv+1eS0484JrPlZWr78cDkS0sqZZAbjQVpDyGH8cq6nyX0MXDHm3kNuXjdpyH6uUpwA=="
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
+      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.28.tgz",
-      "integrity": "sha512-eFRKzd304qAQsadPVuR35OVEYi9vdpaxK+J943dFY9S30dMaemDde8imXVxXxm0mUxe3Okq46BFU4XewqY4wxw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
+      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
       "cpu": [
         "arm"
       ],
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-P4GNhOVQNqE88akuPCjKUMP3lFW49rvFeIgv1XmL5I2/CGd2eWOq7qwxS1Y4RvthRk3zqhMbuKTSok3GTzaa9Q==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
+      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
       "cpu": [
         "arm64"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-ipOc7Nx8FAWwfxwHcRPQyPEb8IiYPypd/OedOm3cPTcwJe1lkAkjKDmQJs7JdD0CbbajEq8msyhztDAorsL9jg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
+      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
       "cpu": [
         "arm64"
       ],
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-lPPxC/T1uUErJdc7jT8Vvt/rtblFn/ff3svO/yxdHAIljIKFXn3OplMu/zYPFqQ0joJXIjw1/U+2NtdfDte3kg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
+      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
       "cpu": [
         "x64"
       ],
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-mCEMprvEuMxY036p5fNwfysZmVyL8WJK8S48rDaAPbDTPYwyUROzrVWeznPKDEZyK4lce+fT8zd7nJzZT8PvsA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
+      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
       "cpu": [
         "x64"
       ],
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.28.tgz",
-      "integrity": "sha512-7oJuSOE5Lok4hSwm39h5XvfXTeI7lZpof7k6lFX+g9Gl4jxT+DWQBvMhafUDCOZ5DLsVHqcTVOybzkYCoaVndA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
+      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
       "cpu": [
         "arm"
       ],
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.28.tgz",
-      "integrity": "sha512-EXgkU6rI8NQE/feNDm7JHKFgZycFnc9xISpEG8GbL+LMe0M+3c50A/iDmF/BAnj9a4XiAk9Y7VbvX1qgSlPDZA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
+      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
       "cpu": [
         "arm64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.28.tgz",
-      "integrity": "sha512-xA5+zm1NY0tEsVCHqpo6hbwDzwxaMeDSeRqu2lVNVX14A93OM75LdHfNjXqDUgqSyqYMUUJ/YOnzmVqHhsBwuw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
+      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
       "cpu": [
         "arm64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.28.tgz",
-      "integrity": "sha512-HU3j82+MXljMyIVMajQYezTQsZ4vj/tVV/+qt2TjfM8o+DEYSc+Ibd77mxY4RRK+A/IRO+ok7a73cHkLtp3WCw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
+      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.28.tgz",
-      "integrity": "sha512-jvLBy3YCytmXrZpHgqBDcDnjwD1n/vNI3zE/vR594hBsSRkSl8u1nL6N284caKVq84y2b77bwwUddwXlBJfypQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
+      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
       "cpu": [
         "x64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-i4H0LWsXenl0YTIyVFY7d/wxuppSQK3nlfTYWCXbIgqFYqtc68S/uZPle1KLIFHNn4etx/8qEKbbgSgCUC/uzQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
+      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-jExfxHdmUTejDLiJOr6ELLpMIAQWsOSXk5mno9YOznysJUMV5EM3gYqz8Ia0pGKwNqwqHOUaVQAK++y6ghxLGQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
+      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
       "cpu": [
         "ia32"
       ],
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-SH1fQKToaPB1fMKFTY1/bCGzsLBGdBsPMB3JcZ8nIojSF2LMuRBqH/u7wyUbR5UZ8DyjfAuaF+BDmIty5bFBsg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
+      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
       "cpu": [
         "x64"
       ],
@@ -555,11 +555,11 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/next": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.28.tgz",
-      "integrity": "sha512-DN1UbGnILF/RtJ/4r2SrVF4XKBr+B74dghcvKgm643MCjK0udzvxVevF3hEgAL9Oq+lz9y9tIGaA/E+O9QvVVQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
+      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
       "dependencies": {
-        "@next/env": "12.3.2-canary.28",
+        "@next/env": "12.3.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -570,22 +570,22 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.2-canary.28",
-        "@next/swc-android-arm64": "12.3.2-canary.28",
-        "@next/swc-darwin-arm64": "12.3.2-canary.28",
-        "@next/swc-darwin-x64": "12.3.2-canary.28",
-        "@next/swc-freebsd-x64": "12.3.2-canary.28",
-        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.28",
-        "@next/swc-linux-arm64-gnu": "12.3.2-canary.28",
-        "@next/swc-linux-arm64-musl": "12.3.2-canary.28",
-        "@next/swc-linux-x64-gnu": "12.3.2-canary.28",
-        "@next/swc-linux-x64-musl": "12.3.2-canary.28",
-        "@next/swc-win32-arm64-msvc": "12.3.2-canary.28",
-        "@next/swc-win32-ia32-msvc": "12.3.2-canary.28",
-        "@next/swc-win32-x64-msvc": "12.3.2-canary.28"
+        "@next/swc-android-arm-eabi": "12.3.1",
+        "@next/swc-android-arm64": "12.3.1",
+        "@next/swc-darwin-arm64": "12.3.1",
+        "@next/swc-darwin-x64": "12.3.1",
+        "@next/swc-freebsd-x64": "12.3.1",
+        "@next/swc-linux-arm-gnueabihf": "12.3.1",
+        "@next/swc-linux-arm64-gnu": "12.3.1",
+        "@next/swc-linux-arm64-musl": "12.3.1",
+        "@next/swc-linux-x64-gnu": "12.3.1",
+        "@next/swc-linux-x64-musl": "12.3.1",
+        "@next/swc-win32-arm64-msvc": "12.3.1",
+        "@next/swc-win32-ia32-msvc": "12.3.1",
+        "@next/swc-win32-x64-msvc": "12.3.1"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/next-image-export-optimizer": {
-      "version": "0.16.1-beta-1",
-      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-1.tgz",
-      "integrity": "sha512-XYXZVCNBx+nyhW6Nojbtogxhv3SGEcfyrUz5dtdflt/vFRIEpZicQrLaNpHNHc/RD392o/iuhvtLXm27B3TMgg==",
+      "version": "0.16.1-beta-2",
+      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-2.tgz",
+      "integrity": "sha512-IS0axLRqubmCX9nv6lRnkJ2up1lmlh1zdaSokNBfLIUlGIMaUg+H1UF5m4O6orytX8F88/IUKE51oN9gKoPCXQ==",
       "dependencies": {
         "cli-progress": "^3.10.0",
         "sharp": "^0.31.0",
@@ -1023,86 +1023,86 @@
   },
   "dependencies": {
     "@next/env": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.28.tgz",
-      "integrity": "sha512-q1ueMCKvS27IBaUZobMkv+1eS0484JrPlZWr78cDkS0sqZZAbjQVpDyGH8cq6nyX0MXDHm3kNuXjdpyH6uUpwA=="
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
+      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.28.tgz",
-      "integrity": "sha512-eFRKzd304qAQsadPVuR35OVEYi9vdpaxK+J943dFY9S30dMaemDde8imXVxXxm0mUxe3Okq46BFU4XewqY4wxw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
+      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-P4GNhOVQNqE88akuPCjKUMP3lFW49rvFeIgv1XmL5I2/CGd2eWOq7qwxS1Y4RvthRk3zqhMbuKTSok3GTzaa9Q==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
+      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-ipOc7Nx8FAWwfxwHcRPQyPEb8IiYPypd/OedOm3cPTcwJe1lkAkjKDmQJs7JdD0CbbajEq8msyhztDAorsL9jg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
+      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-lPPxC/T1uUErJdc7jT8Vvt/rtblFn/ff3svO/yxdHAIljIKFXn3OplMu/zYPFqQ0joJXIjw1/U+2NtdfDte3kg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
+      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.28.tgz",
-      "integrity": "sha512-mCEMprvEuMxY036p5fNwfysZmVyL8WJK8S48rDaAPbDTPYwyUROzrVWeznPKDEZyK4lce+fT8zd7nJzZT8PvsA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
+      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.28.tgz",
-      "integrity": "sha512-7oJuSOE5Lok4hSwm39h5XvfXTeI7lZpof7k6lFX+g9Gl4jxT+DWQBvMhafUDCOZ5DLsVHqcTVOybzkYCoaVndA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
+      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.28.tgz",
-      "integrity": "sha512-EXgkU6rI8NQE/feNDm7JHKFgZycFnc9xISpEG8GbL+LMe0M+3c50A/iDmF/BAnj9a4XiAk9Y7VbvX1qgSlPDZA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
+      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.28.tgz",
-      "integrity": "sha512-xA5+zm1NY0tEsVCHqpo6hbwDzwxaMeDSeRqu2lVNVX14A93OM75LdHfNjXqDUgqSyqYMUUJ/YOnzmVqHhsBwuw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
+      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.28.tgz",
-      "integrity": "sha512-HU3j82+MXljMyIVMajQYezTQsZ4vj/tVV/+qt2TjfM8o+DEYSc+Ibd77mxY4RRK+A/IRO+ok7a73cHkLtp3WCw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
+      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.28.tgz",
-      "integrity": "sha512-jvLBy3YCytmXrZpHgqBDcDnjwD1n/vNI3zE/vR594hBsSRkSl8u1nL6N284caKVq84y2b77bwwUddwXlBJfypQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
+      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-i4H0LWsXenl0YTIyVFY7d/wxuppSQK3nlfTYWCXbIgqFYqtc68S/uZPle1KLIFHNn4etx/8qEKbbgSgCUC/uzQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
+      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-jExfxHdmUTejDLiJOr6ELLpMIAQWsOSXk5mno9YOznysJUMV5EM3gYqz8Ia0pGKwNqwqHOUaVQAK++y6ghxLGQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
+      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.28.tgz",
-      "integrity": "sha512-SH1fQKToaPB1fMKFTY1/bCGzsLBGdBsPMB3JcZ8nIojSF2LMuRBqH/u7wyUbR5UZ8DyjfAuaF+BDmIty5bFBsg==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
+      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
       "optional": true
     },
     "@swc/helpers": {
@@ -1344,24 +1344,24 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "next": {
-      "version": "12.3.2-canary.28",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.28.tgz",
-      "integrity": "sha512-DN1UbGnILF/RtJ/4r2SrVF4XKBr+B74dghcvKgm643MCjK0udzvxVevF3hEgAL9Oq+lz9y9tIGaA/E+O9QvVVQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
+      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
       "requires": {
-        "@next/env": "12.3.2-canary.28",
-        "@next/swc-android-arm-eabi": "12.3.2-canary.28",
-        "@next/swc-android-arm64": "12.3.2-canary.28",
-        "@next/swc-darwin-arm64": "12.3.2-canary.28",
-        "@next/swc-darwin-x64": "12.3.2-canary.28",
-        "@next/swc-freebsd-x64": "12.3.2-canary.28",
-        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.28",
-        "@next/swc-linux-arm64-gnu": "12.3.2-canary.28",
-        "@next/swc-linux-arm64-musl": "12.3.2-canary.28",
-        "@next/swc-linux-x64-gnu": "12.3.2-canary.28",
-        "@next/swc-linux-x64-musl": "12.3.2-canary.28",
-        "@next/swc-win32-arm64-msvc": "12.3.2-canary.28",
-        "@next/swc-win32-ia32-msvc": "12.3.2-canary.28",
-        "@next/swc-win32-x64-msvc": "12.3.2-canary.28",
+        "@next/env": "12.3.1",
+        "@next/swc-android-arm-eabi": "12.3.1",
+        "@next/swc-android-arm64": "12.3.1",
+        "@next/swc-darwin-arm64": "12.3.1",
+        "@next/swc-darwin-x64": "12.3.1",
+        "@next/swc-freebsd-x64": "12.3.1",
+        "@next/swc-linux-arm-gnueabihf": "12.3.1",
+        "@next/swc-linux-arm64-gnu": "12.3.1",
+        "@next/swc-linux-arm64-musl": "12.3.1",
+        "@next/swc-linux-x64-gnu": "12.3.1",
+        "@next/swc-linux-x64-musl": "12.3.1",
+        "@next/swc-win32-arm64-msvc": "12.3.1",
+        "@next/swc-win32-ia32-msvc": "12.3.1",
+        "@next/swc-win32-x64-msvc": "12.3.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -1370,9 +1370,9 @@
       }
     },
     "next-image-export-optimizer": {
-      "version": "0.16.1-beta-1",
-      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-1.tgz",
-      "integrity": "sha512-XYXZVCNBx+nyhW6Nojbtogxhv3SGEcfyrUz5dtdflt/vFRIEpZicQrLaNpHNHc/RD392o/iuhvtLXm27B3TMgg==",
+      "version": "0.16.1-beta-2",
+      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-2.tgz",
+      "integrity": "sha512-IS0axLRqubmCX9nv6lRnkJ2up1lmlh1zdaSokNBfLIUlGIMaUg+H1UF5m4O6orytX8F88/IUKE51oN9gKoPCXQ==",
       "requires": {
         "cli-progress": "^3.10.0",
         "sharp": "^0.31.0",

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "example",
       "dependencies": {
-        "next": "^12.1.6",
-        "next-image-export-optimizer": "^0.16.0",
+        "next": "^12.3.2-canary.28",
+        "next-image-export-optimizer": "^0.16.1-beta-1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -17,14 +17,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.28.tgz",
+      "integrity": "sha512-q1ueMCKvS27IBaUZobMkv+1eS0484JrPlZWr78cDkS0sqZZAbjQVpDyGH8cq6nyX0MXDHm3kNuXjdpyH6uUpwA=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.28.tgz",
+      "integrity": "sha512-eFRKzd304qAQsadPVuR35OVEYi9vdpaxK+J943dFY9S30dMaemDde8imXVxXxm0mUxe3Okq46BFU4XewqY4wxw==",
       "cpu": [
         "arm"
       ],
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-P4GNhOVQNqE88akuPCjKUMP3lFW49rvFeIgv1XmL5I2/CGd2eWOq7qwxS1Y4RvthRk3zqhMbuKTSok3GTzaa9Q==",
       "cpu": [
         "arm64"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-ipOc7Nx8FAWwfxwHcRPQyPEb8IiYPypd/OedOm3cPTcwJe1lkAkjKDmQJs7JdD0CbbajEq8msyhztDAorsL9jg==",
       "cpu": [
         "arm64"
       ],
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-lPPxC/T1uUErJdc7jT8Vvt/rtblFn/ff3svO/yxdHAIljIKFXn3OplMu/zYPFqQ0joJXIjw1/U+2NtdfDte3kg==",
       "cpu": [
         "x64"
       ],
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-mCEMprvEuMxY036p5fNwfysZmVyL8WJK8S48rDaAPbDTPYwyUROzrVWeznPKDEZyK4lce+fT8zd7nJzZT8PvsA==",
       "cpu": [
         "x64"
       ],
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.28.tgz",
+      "integrity": "sha512-7oJuSOE5Lok4hSwm39h5XvfXTeI7lZpof7k6lFX+g9Gl4jxT+DWQBvMhafUDCOZ5DLsVHqcTVOybzkYCoaVndA==",
       "cpu": [
         "arm"
       ],
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.28.tgz",
+      "integrity": "sha512-EXgkU6rI8NQE/feNDm7JHKFgZycFnc9xISpEG8GbL+LMe0M+3c50A/iDmF/BAnj9a4XiAk9Y7VbvX1qgSlPDZA==",
       "cpu": [
         "arm64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.28.tgz",
+      "integrity": "sha512-xA5+zm1NY0tEsVCHqpo6hbwDzwxaMeDSeRqu2lVNVX14A93OM75LdHfNjXqDUgqSyqYMUUJ/YOnzmVqHhsBwuw==",
       "cpu": [
         "arm64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.28.tgz",
+      "integrity": "sha512-HU3j82+MXljMyIVMajQYezTQsZ4vj/tVV/+qt2TjfM8o+DEYSc+Ibd77mxY4RRK+A/IRO+ok7a73cHkLtp3WCw==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.28.tgz",
+      "integrity": "sha512-jvLBy3YCytmXrZpHgqBDcDnjwD1n/vNI3zE/vR594hBsSRkSl8u1nL6N284caKVq84y2b77bwwUddwXlBJfypQ==",
       "cpu": [
         "x64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-i4H0LWsXenl0YTIyVFY7d/wxuppSQK3nlfTYWCXbIgqFYqtc68S/uZPle1KLIFHNn4etx/8qEKbbgSgCUC/uzQ==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-jExfxHdmUTejDLiJOr6ELLpMIAQWsOSXk5mno9YOznysJUMV5EM3gYqz8Ia0pGKwNqwqHOUaVQAK++y6ghxLGQ==",
       "cpu": [
         "ia32"
       ],
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-SH1fQKToaPB1fMKFTY1/bCGzsLBGdBsPMB3JcZ8nIojSF2LMuRBqH/u7wyUbR5UZ8DyjfAuaF+BDmIty5bFBsg==",
       "cpu": [
         "x64"
       ],
@@ -555,11 +555,11 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.28.tgz",
+      "integrity": "sha512-DN1UbGnILF/RtJ/4r2SrVF4XKBr+B74dghcvKgm643MCjK0udzvxVevF3hEgAL9Oq+lz9y9tIGaA/E+O9QvVVQ==",
       "dependencies": {
-        "@next/env": "12.3.1",
+        "@next/env": "12.3.2-canary.28",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -570,22 +570,22 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1"
+        "@next/swc-android-arm-eabi": "12.3.2-canary.28",
+        "@next/swc-android-arm64": "12.3.2-canary.28",
+        "@next/swc-darwin-arm64": "12.3.2-canary.28",
+        "@next/swc-darwin-x64": "12.3.2-canary.28",
+        "@next/swc-freebsd-x64": "12.3.2-canary.28",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.28",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.28",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.28",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.28",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.28",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.28",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.28",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.28"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/next-image-export-optimizer": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.0.tgz",
-      "integrity": "sha512-pPf1nCWTIIjEPNoXz5h2n/xlAwbjTn3mphmPBtK34rrAWlJX9294mlLq9kJeGYWmBRrhQvfploHKru2VhyoT1w==",
+      "version": "0.16.1-beta-1",
+      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-1.tgz",
+      "integrity": "sha512-XYXZVCNBx+nyhW6Nojbtogxhv3SGEcfyrUz5dtdflt/vFRIEpZicQrLaNpHNHc/RD392o/iuhvtLXm27B3TMgg==",
       "dependencies": {
         "cli-progress": "^3.10.0",
         "sharp": "^0.31.0",
@@ -1023,86 +1023,86 @@
   },
   "dependencies": {
     "@next/env": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.2-canary.28.tgz",
+      "integrity": "sha512-q1ueMCKvS27IBaUZobMkv+1eS0484JrPlZWr78cDkS0sqZZAbjQVpDyGH8cq6nyX0MXDHm3kNuXjdpyH6uUpwA=="
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.28.tgz",
+      "integrity": "sha512-eFRKzd304qAQsadPVuR35OVEYi9vdpaxK+J943dFY9S30dMaemDde8imXVxXxm0mUxe3Okq46BFU4XewqY4wxw==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-P4GNhOVQNqE88akuPCjKUMP3lFW49rvFeIgv1XmL5I2/CGd2eWOq7qwxS1Y4RvthRk3zqhMbuKTSok3GTzaa9Q==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-ipOc7Nx8FAWwfxwHcRPQyPEb8IiYPypd/OedOm3cPTcwJe1lkAkjKDmQJs7JdD0CbbajEq8msyhztDAorsL9jg==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-lPPxC/T1uUErJdc7jT8Vvt/rtblFn/ff3svO/yxdHAIljIKFXn3OplMu/zYPFqQ0joJXIjw1/U+2NtdfDte3kg==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.28.tgz",
+      "integrity": "sha512-mCEMprvEuMxY036p5fNwfysZmVyL8WJK8S48rDaAPbDTPYwyUROzrVWeznPKDEZyK4lce+fT8zd7nJzZT8PvsA==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.28.tgz",
+      "integrity": "sha512-7oJuSOE5Lok4hSwm39h5XvfXTeI7lZpof7k6lFX+g9Gl4jxT+DWQBvMhafUDCOZ5DLsVHqcTVOybzkYCoaVndA==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.28.tgz",
+      "integrity": "sha512-EXgkU6rI8NQE/feNDm7JHKFgZycFnc9xISpEG8GbL+LMe0M+3c50A/iDmF/BAnj9a4XiAk9Y7VbvX1qgSlPDZA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.28.tgz",
+      "integrity": "sha512-xA5+zm1NY0tEsVCHqpo6hbwDzwxaMeDSeRqu2lVNVX14A93OM75LdHfNjXqDUgqSyqYMUUJ/YOnzmVqHhsBwuw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.28.tgz",
+      "integrity": "sha512-HU3j82+MXljMyIVMajQYezTQsZ4vj/tVV/+qt2TjfM8o+DEYSc+Ibd77mxY4RRK+A/IRO+ok7a73cHkLtp3WCw==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.28.tgz",
+      "integrity": "sha512-jvLBy3YCytmXrZpHgqBDcDnjwD1n/vNI3zE/vR594hBsSRkSl8u1nL6N284caKVq84y2b77bwwUddwXlBJfypQ==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-i4H0LWsXenl0YTIyVFY7d/wxuppSQK3nlfTYWCXbIgqFYqtc68S/uZPle1KLIFHNn4etx/8qEKbbgSgCUC/uzQ==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-jExfxHdmUTejDLiJOr6ELLpMIAQWsOSXk5mno9YOznysJUMV5EM3gYqz8Ia0pGKwNqwqHOUaVQAK++y6ghxLGQ==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.28.tgz",
+      "integrity": "sha512-SH1fQKToaPB1fMKFTY1/bCGzsLBGdBsPMB3JcZ8nIojSF2LMuRBqH/u7wyUbR5UZ8DyjfAuaF+BDmIty5bFBsg==",
       "optional": true
     },
     "@swc/helpers": {
@@ -1344,24 +1344,24 @@
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+      "version": "12.3.2-canary.28",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.2-canary.28.tgz",
+      "integrity": "sha512-DN1UbGnILF/RtJ/4r2SrVF4XKBr+B74dghcvKgm643MCjK0udzvxVevF3hEgAL9Oq+lz9y9tIGaA/E+O9QvVVQ==",
       "requires": {
-        "@next/env": "12.3.1",
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1",
+        "@next/env": "12.3.2-canary.28",
+        "@next/swc-android-arm-eabi": "12.3.2-canary.28",
+        "@next/swc-android-arm64": "12.3.2-canary.28",
+        "@next/swc-darwin-arm64": "12.3.2-canary.28",
+        "@next/swc-darwin-x64": "12.3.2-canary.28",
+        "@next/swc-freebsd-x64": "12.3.2-canary.28",
+        "@next/swc-linux-arm-gnueabihf": "12.3.2-canary.28",
+        "@next/swc-linux-arm64-gnu": "12.3.2-canary.28",
+        "@next/swc-linux-arm64-musl": "12.3.2-canary.28",
+        "@next/swc-linux-x64-gnu": "12.3.2-canary.28",
+        "@next/swc-linux-x64-musl": "12.3.2-canary.28",
+        "@next/swc-win32-arm64-msvc": "12.3.2-canary.28",
+        "@next/swc-win32-ia32-msvc": "12.3.2-canary.28",
+        "@next/swc-win32-x64-msvc": "12.3.2-canary.28",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -1370,9 +1370,9 @@
       }
     },
     "next-image-export-optimizer": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.0.tgz",
-      "integrity": "sha512-pPf1nCWTIIjEPNoXz5h2n/xlAwbjTn3mphmPBtK34rrAWlJX9294mlLq9kJeGYWmBRrhQvfploHKru2VhyoT1w==",
+      "version": "0.16.1-beta-1",
+      "resolved": "https://registry.npmjs.org/next-image-export-optimizer/-/next-image-export-optimizer-0.16.1-beta-1.tgz",
+      "integrity": "sha512-XYXZVCNBx+nyhW6Nojbtogxhv3SGEcfyrUz5dtdflt/vFRIEpZicQrLaNpHNHc/RD392o/iuhvtLXm27B3TMgg==",
       "requires": {
         "cli-progress": "^3.10.0",
         "sharp": "^0.31.0",

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^12.1.6",
-    "next-image-export-optimizer": "^0.16.0",
+    "next": "^12.3.2-canary.28",
+    "next-image-export-optimizer": "^0.16.1-beta-1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "^12.3.2-canary.28",
-    "next-image-export-optimizer": "^0.16.1-beta-1",
+    "next": "^12.3.1",
+    "next-image-export-optimizer": "^0.16.1-beta-2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/example/pages/fixedImage.js
+++ b/example/pages/fixedImage.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import ExportedImage from "../localTestComponent/ExportedImage";
+import ExportedImageFuture from "../localTestComponent/ExportedImageFuture";
 // import ExportedImage from "next-image-export-optimizer";
 
 import styles from "../styles/Home.module.css";
@@ -16,8 +17,9 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className={styles.main}>
-        <h1 className={styles.title}>Next-Image-Export-Optimizer</h1>
+      <main>
+        <h1>Next-Image-Export-Optimizer</h1>
+        <h2>Fixed size test page</h2>
         <div
           style={{
             position: "relative",
@@ -27,18 +29,33 @@ export default function Home() {
           }}
         >
           {[16, 32, 48, 64, 96, 128, 256, 384].map((size) => (
-            <ExportedImage
-              key={size}
-              src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
-              layout="fixed"
-              width={size}
-              height={size}
-              useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
-              id={`test_image_${size}`}
-              objectFit="cover"
-              priority={true}
-              alt={"test_image"}
-            />
+            <div style={{ display: "flex", margin: "4px" }} key={size}>
+              <ExportedImage
+                src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+                layout="fixed"
+                width={size}
+                height={size}
+                useWebp={
+                  process.env.nextImageExportOptimizer_storePicturesInWEBP
+                }
+                id={`test_image_${size}`}
+                objectFit="cover"
+                priority={true}
+                alt={"test_image"}
+              />
+              <ExportedImageFuture
+                src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+                width={size}
+                height={size}
+                useWebp={
+                  process.env.nextImageExportOptimizer_storePicturesInWEBP
+                }
+                id={`test_image_${size}_future`}
+                style={{ objectFit: "cover" }}
+                priority={true}
+                alt={"test_image"}
+              />
+            </div>
           ))}
         </div>
       </main>

--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -35,7 +35,7 @@ export default function Home() {
             layout="fill"
             id="test_image"
             objectFit="cover"
-            // priority={true}
+            priority
             useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
             alt={"test_image"}
           />
@@ -55,7 +55,7 @@ export default function Home() {
             id="test_image_static"
             layout="responsive"
             useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
-            // priority
+            priority
           />
         </div>
         <h2>Optimized example future</h2>

--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -1,5 +1,7 @@
 import Head from "next/head";
 import ExportedImage from "../localTestComponent/ExportedImage";
+import ExportedImageFuture from "../localTestComponent/ExportedImageFuture";
+// import ExportedImageFuture from "next-image-export-optimizer/future/ExportedImage";
 // import ExportedImage from "next-image-export-optimizer";
 
 import styles from "../styles/Home.module.css";
@@ -33,7 +35,7 @@ export default function Home() {
             layout="fill"
             id="test_image"
             objectFit="cover"
-            priority={true}
+            // priority={true}
             useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
             alt={"test_image"}
           />
@@ -53,7 +55,59 @@ export default function Home() {
             id="test_image_static"
             layout="responsive"
             useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
-            priority
+            // priority
+          />
+        </div>
+        <h2>Optimized example future</h2>
+        <div
+          style={{
+            marginBottom: "3rem",
+          }}
+        >
+          <ExportedImageFuture
+            src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+            id="test_image_future"
+            useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+            alt={"test_image"}
+            width={500}
+            height={300}
+          />
+        </div>
+        <h2>Optimized example future (fill)</h2>
+        <div
+          style={{
+            position: "relative",
+            width: "50%",
+            height: "200px",
+            marginBottom: "3rem",
+          }}
+        >
+          <ExportedImageFuture
+            src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+            id="test_image_future_fill"
+            useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+            alt={"test_image"}
+            fill
+            style={{ objectFit: "cover" }}
+          />
+        </div>
+        <h2>Optimized example future (static import)</h2>
+
+        <div
+          style={{
+            position: "relative",
+            marginBottom: "3rem",
+            width: "100%",
+          }}
+        >
+          <ExportedImageFuture
+            src={testPictureStatic}
+            alt="test_image_static"
+            id="test_image_static_future"
+            sizes="100vw"
+            style={{ width: "100%", height: "auto" }}
+            useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+            // priority
           />
         </div>
 

--- a/example/pages/nested/page.js
+++ b/example/pages/nested/page.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ExportedImage from "../../localTestComponent/ExportedImage";
+import ExportedImageFuture from "../../localTestComponent/ExportedImageFuture";
 import testPictureStatic from "../../public/chris-zhang-Jq8-3Bmh1pQ-unsplash_static.jpg";
 
 function Page() {
@@ -58,6 +59,44 @@ function Page() {
           objectFit="cover"
           useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
           alt={"test_image"}
+        />
+      </div>
+      <h2>Optimized example future</h2>
+      <div
+        style={{
+          position: "relative",
+          width: "50%",
+          height: "200px",
+          marginBottom: "3rem",
+        }}
+      >
+        <ExportedImageFuture
+          src="images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"
+          id="test_image_future"
+          priority={true}
+          useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+          alt={"test_image"}
+          fill
+          style={{ objectFit: "cover" }}
+        />
+      </div>
+      <h2>Optimized example future (static import)</h2>
+
+      <div
+        style={{
+          position: "relative",
+          marginBottom: "3rem",
+          width: "100%",
+        }}
+      >
+        <ExportedImageFuture
+          src={testPictureStatic}
+          alt="test_image_static"
+          id="test_image_static_future"
+          sizes="100vw"
+          style={{ width: "100%", height: "auto" }}
+          useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+          priority
         />
       </div>
     </div>

--- a/example/pages/nested/page_fixed.js
+++ b/example/pages/nested/page_fixed.js
@@ -1,0 +1,53 @@
+import React from "react";
+import ExportedImage from "../../localTestComponent/ExportedImage";
+import ExportedImageFuture from "../../localTestComponent/ExportedImageFuture";
+import testPictureStatic from "../../public/chris-zhang-Jq8-3Bmh1pQ-unsplash_static.jpg";
+
+function Page() {
+  return (
+    <div>
+      <h1>Nested page test</h1>
+
+      <h2>Optimized example with fixed size (static import)</h2>
+
+      <div
+        style={{
+          position: "relative",
+          marginBottom: "3rem",
+          width: "100%",
+        }}
+      >
+        <ExportedImage
+          src={testPictureStatic}
+          alt="test_image_static_fixed"
+          id="test_image_static_fixed"
+          width={300}
+          height={100}
+          useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+          objectFit="cover"
+        />
+      </div>
+      <h2>Optimized example with fixed size future (static import)</h2>
+
+      <div
+        style={{
+          position: "relative",
+          marginBottom: "3rem",
+          width: "100%",
+        }}
+      >
+        <ExportedImageFuture
+          src={testPictureStatic}
+          alt="test_image_static_fixed"
+          id="test_image_static_fixed_future"
+          width={300}
+          height={100}
+          useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+          style={{ objectFit: "cover" }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Page;

--- a/example/pages/smallImage.js
+++ b/example/pages/smallImage.js
@@ -1,5 +1,7 @@
 import Head from "next/head";
 import ExportedImage from "../localTestComponent/ExportedImage";
+import ExportedImageFuture from "../localTestComponent/ExportedImageFuture";
+import smallImage from "../public/images/chris-zhang-Jq8-3Bmh1pQ-unsplash_small.jpg";
 
 import styles from "../styles/Home.module.css";
 
@@ -32,6 +34,20 @@ export default function Home() {
             id="test_image"
             objectFit="cover"
             priority={true}
+            useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
+            alt={"test_image"}
+          />
+        </div>
+        <h2>Optimized example future</h2>
+
+        <div
+          style={{
+            marginBottom: "3rem",
+          }}
+        >
+          <ExportedImageFuture
+            src={smallImage}
+            id="test_image_future"
             useWebp={process.env.nextImageExportOptimizer_storePicturesInWEBP}
             alt={"test_image"}
           />

--- a/example/public/images/next-image-export-optimizer-hashes.json
+++ b/example/public/images/next-image-export-optimizer-hashes.json
@@ -1,6 +1,8 @@
 {
-    "chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg": "GosbP23UgS8POfcjoLyBFk12k-I5ItcFkGSzM+Bbu50=",
-    "ollie-barker-jones-K52HVSPVvKI-unsplash.jpg": "o5rzMmrreJ3JcKHjYVpEgK19nOChpRqgmvvz8XrR9iU=",
-    "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0.jpg": "5PO53DTMwWwMqPRcxHEgQ6Hmlmo8dFAa2Z2q7Plm3Rk=",
-    "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.jpg": "X9K5QfNpufrqW3iWHQBigHKVG1iyjAZe9ik-ujhuBhU="
+    "/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg": "GosbP23UgS8POfcjoLyBFk12k-I5ItcFkGSzM+Bbu50=",
+    "/chris-zhang-Jq8-3Bmh1pQ-unsplash_small.jpg": "X9K5QfNpufrqW3iWHQBigHKVG1iyjAZe9ik-ujhuBhU=",
+    "subfolder/ollie-barker-jones-K52HVSPVvKI-unsplash.jpg": "5iilVWAkWe+3mUGE9ZA+1Y7j4fMQ1l4ppWkUlYW1gnA=",
+    "subfolder/subfolder2/ollie-barker-jones-K52HVSPVvKI-unsplash.jpg": "o5rzMmrreJ3JcKHjYVpEgK19nOChpRqgmvvz8XrR9iU=",
+    "/chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23.jpg": "X4HbBWoEaZjJQAdNi6FP1VPRNiyUL0XxJStlMHYcKu4=",
+    "/chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0.jpg": "5PO53DTMwWwMqPRcxHEgQ6Hmlmo8dFAa2Z2q7Plm3Rk="
 }

--- a/example/test/e2e/fixedImageSizeTest.spec.mjs
+++ b/example/test/e2e/fixedImageSizeTest.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import getImageById from "./getImageById.js";
 
 const widths = [16, 32, 48, 64, 96, 128, 256, 384];
 const correctSrc = {
@@ -52,18 +53,19 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator(`#test_image_${width}`);
       await img.click();
       const testWidth = width;
-      const image = await page.evaluate((testWidth) => {
-        let img = document.getElementById(`test_image_${testWidth}`);
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      }, testWidth);
+
+      const image = await getImageById(page, `test_image_${testWidth}`);
 
       expect(
         correctSrc[width.toString()].includes(image.currentSrc)
+      ).toBeTruthy();
+      const image_future = await getImageById(
+        page,
+        `test_image_${testWidth}_future`
+      );
+
+      expect(
+        correctSrc[width.toString()].includes(image_future.currentSrc)
       ).toBeTruthy();
     });
   });

--- a/example/test/e2e/getImageById.js
+++ b/example/test/e2e/getImageById.js
@@ -1,0 +1,11 @@
+module.exports = async function getImageById(page, imageId) {
+  return await page.evaluate((imageId) => {
+    let img = document.getElementById(imageId);
+    return {
+      src: img.src,
+      currentSrc: img.currentSrc,
+      naturalWidth: img.naturalWidth,
+      width: img.width,
+    };
+  }, imageId);
+};

--- a/example/test/e2e/imageSizeTest.spec.mjs
+++ b/example/test/e2e/imageSizeTest.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import getImageById from "./getImageById.js";
 
 const widths = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
 const correctSrc = {
@@ -60,17 +61,11 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image");
       expect(image.currentSrc).toBe(correctSrc[width.toString()]);
+
+      const image_future = await getImageById(page, `test_image_future_fill`);
+      expect(image_future.currentSrc).toBe(correctSrc[width.toString()]);
     });
     test("should check the image size for the statically imported image", async ({
       page,
@@ -84,16 +79,13 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image_static");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image_static");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
+      const image = await getImageById(page, "test_image_static");
       expect(image.currentSrc).toBe(correctSrcStaticImage[width.toString()]);
+
+      const image_future = await getImageById(page, `test_image_static_future`);
+      expect(image_future.currentSrc).toBe(
+        correctSrcStaticImage[width.toString()]
+      );
     });
     test("should check the image size for the statically imported image in the nested route", async ({
       page,
@@ -105,39 +97,34 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image_static");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image_static");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image_static");
       expect(image.currentSrc).toBe(correctSrcStaticImage[width.toString()]);
+
+      const image_future = await getImageById(page, "test_image_static_future");
+      expect(image_future.currentSrc).toBe(
+        correctSrcStaticImage[width.toString()]
+      );
     });
     test("should check the image size for the statically imported image with fixed size in the nested route", async ({
       page,
     }) => {
-      await page.goto("/nested/page", {
+      await page.goto("/nested/page_fixed", {
         waitUntil: "networkidle",
       });
 
       const img = await page.locator("#test_image_static_fixed");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image_static_fixed");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image_static_fixed");
       expect(image.currentSrc).toBe(
+        "http://localhost:8080/nextImageExportOptimizer/chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-384.WEBP"
+      );
+
+      const image_future = await getImageById(
+        page,
+        "test_image_static_fixed_future"
+      );
+      expect(image_future.currentSrc).toBe(
         "http://localhost:8080/nextImageExportOptimizer/chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-384.WEBP"
       );
     });
@@ -152,17 +139,11 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image");
       expect(image.currentSrc).toBe(correctSrc[width.toString()]);
+
+      const image_future = await getImageById(page, "test_image_future");
+      expect(image_future.currentSrc).toBe(correctSrc[width.toString()]);
     });
 
     test("should check the image size for the statically imported image in the nested slug route", async ({
@@ -175,16 +156,7 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image_static");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image_static");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image_static");
       expect(image.currentSrc).toBe(correctSrcStaticImage[width.toString()]);
     });
 
@@ -200,16 +172,7 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image_subfolder");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image_subfolder");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image_subfolder");
       expect(image.currentSrc).toBe(correctSrcSubfolder[width.toString()]);
     });
     test("should check the image size for the typescript test page", async ({
@@ -224,16 +187,7 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image");
       expect(image.currentSrc).toBe(correctSrc[width.toString()]);
     });
     test("should check the image size for the small Image test page", async ({
@@ -248,16 +202,7 @@ for (let index = 0; index < widths.length; index++) {
       const img = await page.locator("#test_image");
       await img.click();
 
-      const image = await page.evaluate(() => {
-        let img = document.getElementById("test_image");
-        return {
-          src: img.src,
-          currentSrc: img.currentSrc,
-          naturalWidth: img.naturalWidth,
-          width: img.width,
-        };
-      });
-
+      const image = await getImageById(page, "test_image");
       expect(image.currentSrc).toBe(correctSrcSmallImage[width.toString()]);
     });
   });

--- a/example/test/e2e/unoptimizedTest.spec.mjs
+++ b/example/test/e2e/unoptimizedTest.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import getImageById from "./getImageById.js";
 
 test.describe(`Test unoptimized image prop`, () => {
   test.use({
@@ -15,15 +16,7 @@ test.describe(`Test unoptimized image prop`, () => {
     const img = await page.locator("#test_image_unoptimized");
     await img.click();
 
-    const image = await page.evaluate(() => {
-      let img = document.getElementById("test_image_unoptimized");
-      return {
-        src: img.src,
-        currentSrc: img.currentSrc,
-        naturalWidth: img.naturalWidth,
-        width: img.width,
-      };
-    });
+    const image = await getImageById(page, "test_image_unoptimized");
 
     expect(image.currentSrc).toBe(
       "http://localhost:8080/images/chris-zhang-Jq8-3Bmh1pQ-unsplash.jpg"

--- a/fileComparison.js
+++ b/fileComparison.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require("fs");
+
+function testFiles(name, path1, path2) {
+  var tmpBuf = fs.readFileSync(path1);
+  var testBuf = fs.readFileSync(path2);
+  const result = Buffer.compare(tmpBuf, testBuf);
+  //   console.log(result);
+  if (result !== 0) {
+    throw new Error(`Files for the ${name} image component are different`);
+  }
+  return result;
+}
+
+testFiles(
+  "legacy",
+  "./example/localTestComponent/ExportedImage.tsx",
+  "./src/ExportedImage.tsx"
+);
+testFiles(
+  "future",
+  "./example/localTestComponent/ExportedImageFuture.tsx",
+  "./src/future/ExportedImage.tsx"
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,30 +60,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
-      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
+      "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
+      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.1",
+        "@babel/generator": "^7.19.3",
+        "@babel/helper-compilation-targets": "^7.19.3",
         "@babel/helper-module-transforms": "^7.19.0",
         "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.1",
+        "@babel/parser": "^7.19.3",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/traverse": "^7.19.3",
+        "@babel/types": "^7.19.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -99,12 +99,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
-      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
+      "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.19.0",
+        "@babel/types": "^7.19.4",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -127,12 +127,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
-      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
+      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.1",
+        "@babel/compat-data": "^7.19.3",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "semver": "^6.3.0"
@@ -219,12 +219,12 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
+      "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.19.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -270,14 +270,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
+      "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/traverse": "^7.19.4",
+        "@babel/types": "^7.19.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
-      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
+      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -572,19 +572,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
-      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
+      "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
+        "@babel/generator": "^7.19.4",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/parser": "^7.19.4",
+        "@babel/types": "^7.19.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -602,13 +602,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
+      "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -622,9 +622,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-      "integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -656,16 +656,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -796,16 +786,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.0.3.tgz",
-      "integrity": "sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.2.0.tgz",
+      "integrity": "sha512-Xz1Wu+ZZxcB3RS8U3HdkFxlRJ7kLXI/by9X7d2/gvseIWPwYu/c1EsYy77cB5iyyHGOy3whS2HycjcuzIF4Jow==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -813,37 +803,37 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.0.3.tgz",
-      "integrity": "sha512-1d0hLbOrM1qQE3eP3DtakeMbKTcXiXP3afWxqz103xPyddS2NhnNghS7MaXx1dcDt4/6p4nlhmeILo2ofgi8cQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.2.0.tgz",
+      "integrity": "sha512-+gyJ3bX+kGEW/eqt/0kI7fLjqiFr3AN8O+rlEl1fYRf7D8h4Sj4tBGo9YOSirvWgvemoH2EPRya35bgvcPFzHQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.0.3",
-        "@jest/reporters": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/reporters": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.0.0",
-        "jest-config": "^29.0.3",
-        "jest-haste-map": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-resolve-dependencies": "^29.0.3",
-        "jest-runner": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
-        "jest-watcher": "^29.0.3",
+        "jest-changed-files": "^29.2.0",
+        "jest-config": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-resolve-dependencies": "^29.2.0",
+        "jest-runner": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
+        "jest-watcher": "^29.2.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -860,88 +850,88 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.3.tgz",
-      "integrity": "sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.2.0.tgz",
+      "integrity": "sha512-foaVv1QVPB31Mno3LlL58PxEQQOLZd9zQfCpyQQCQIpUAtdFP1INBjkphxrCfKT13VxpA0z5jFGIkmZk0DAg2Q==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
-        "jest-mock": "^29.0.3"
+        "jest-mock": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.3.tgz",
-      "integrity": "sha512-6W7K+fsI23FQ01H/BWccPyDZFrnU9QlzDcKOjrNVU5L8yUORFAJJIpmyxWPW70+X624KUNqzZwPThPMX28aXEQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.2.0.tgz",
+      "integrity": "sha512-+3lxcYL9e0xPJGOR33utxxejn+Mulz40kY0oy0FVsmIESW87NZDJ7B1ovaIqeX0xIgPX4laS5SGlqD2uSoBMcw==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.0.3",
-        "jest-snapshot": "^29.0.3"
+        "expect": "^29.2.0",
+        "jest-snapshot": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.3.tgz",
-      "integrity": "sha512-i1xUkau7K/63MpdwiRqaxgZOjxYs4f0WMTGJnYwUKubsNRZSeQbLorS7+I4uXVF9KQ5r61BUPAUMZ7Lf66l64Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.2.0.tgz",
+      "integrity": "sha512-nz2IDF7nb1qmj9hx8Ja3MFab2q9Ml8QbOaaeJNyX5JQJHU8QUvEDiMctmhGEkk3Kzr8w8vAqz4hPk/ogJSrUhg==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.0.0"
+        "jest-get-type": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.3.tgz",
-      "integrity": "sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.2.0.tgz",
+      "integrity": "sha512-mX0V0uQsgeSLTt0yTqanAhhpeUKMGd2uq+PSLAfO40h72bvfNNQ7pIEl9vIwNMFxRih1ENveEjSBsLjxGGDPSw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^29.0.3",
-        "jest-mock": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "jest-message-util": "^29.2.0",
+        "jest-mock": "^29.2.0",
+        "jest-util": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.3.tgz",
-      "integrity": "sha512-YqGHT65rFY2siPIHHFjuCGUsbzRjdqkwbat+Of6DmYRg5shIXXrLdZoVE/+TJ9O1dsKsFmYhU58JvIbZRU1Z9w==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.2.0.tgz",
+      "integrity": "sha512-JQxtEVNWiai1p3PIzAJZSyEqQdAJGvNKvinZDPfu0mhiYEVx6E+PiBuDWj1sVUW8hzu+R3DVqaWC9K2xcLRIAA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.0.3",
-        "@jest/expect": "^29.0.3",
-        "@jest/types": "^29.0.3",
-        "jest-mock": "^29.0.3"
+        "@jest/environment": "^29.2.0",
+        "@jest/expect": "^29.2.0",
+        "@jest/types": "^29.2.0",
+        "jest-mock": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.0.3.tgz",
-      "integrity": "sha512-3+QU3d4aiyOWfmk1obDerie4XNCaD5Xo1IlKNde2yGEi02WQD+ZQD0i5Hgqm1e73sMV7kw6pMlCnprtEwEVwxw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.2.0.tgz",
+      "integrity": "sha512-BXoAJatxTZ18U0cwD7C8qBo8V6vef8AXYRBZdhqE5DF9CmpqmhMfw9c7OUvYqMTnBBK9A0NgXGO4Lc9EJzdHvw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -954,13 +944,12 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
-        "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^9.0.1"
       },
       "engines": {
@@ -988,9 +977,9 @@
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
-      "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.2.0.tgz",
+      "integrity": "sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -1002,13 +991,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.0.3.tgz",
-      "integrity": "sha512-vViVnQjCgTmbhDKEonKJPtcFe9G/CJO4/Np4XwYJah+lF2oI7KKeRp8t1dFvv44wN2NdbDb/qC6pi++Vpp0Dlg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.2.0.tgz",
+      "integrity": "sha512-l76EPJ6QqtzsCLS4aimJqWO53pxZ82o3aE+Brcmo1HJ/phb9+MR7gPhyDdN6VSGaLJCRVJBZgWEhAEz+qON0Fw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -1017,14 +1006,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.0.3.tgz",
-      "integrity": "sha512-Hf4+xYSWZdxTNnhDykr8JBs0yBN/nxOXyUQWfotBUqqy0LF9vzcFB0jm/EDNZCx587znLWTIgxcokW7WeZMobQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.2.0.tgz",
+      "integrity": "sha512-NCnjZcGnVdva6IDqF7TCuFsXs2F1tohiNF9sasSJNzD7VfN5ic9XgcS/oPDalGiPLxCmGKj4kewqqrKAqBACcQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.0.3",
+        "@jest/test-result": "^29.2.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1032,22 +1021,22 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.3.tgz",
-      "integrity": "sha512-C5ihFTRYaGDbi/xbRQRdbo5ddGtI4VSpmL6AIcZxdhwLbXMa7PcXxxqyI91vGOFHnn5aVM3WYnYKCHEqmLVGzg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.2.0.tgz",
+      "integrity": "sha512-NXMujGHy+B4DAj4dGnVPD0SIXlR2Z/N8Gp9h3mF66kcIRult1WWqY3/CEIrJcKviNWaFPYhZjCG2L3fteWzcUw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1058,9 +1047,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.3.tgz",
-      "integrity": "sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.0.tgz",
+      "integrity": "sha512-mfgpQz4Z2xGo37m6KD8xEpKelaVzvYVRijmLPePn9pxgaPEtX+SqIyPNzzoeCPXKYbB4L/wYSgXDL8o3Gop78Q==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -1112,13 +1101,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@next/env": {
@@ -1371,13 +1360,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
-      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.26.0"
+        "playwright-core": "1.27.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1387,9 +1376,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.43",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.43.tgz",
-      "integrity": "sha512-1orQTvtazZmsPeBroJjysvsOQCYV2yjWlebkSY38pl5vr2tdLjEJ+LoxITlGNZaH2RE19WlAwQMkH/7C14wLfw==",
+      "version": "0.24.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.46.tgz",
+      "integrity": "sha512-ng4ut1z2MCBhK/NwDVwIQp3pAUOCs/KNaW3cBxdFB2xTDrOuo1xuNmpr/9HHFhxqIvHrs1NTH3KJg6q+JSy1Kw==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -1439,9 +1428,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.3.tgz",
-      "integrity": "sha512-OGx3Qpw+czNSaea1ojP2X2wxrGtYicQxH1QnzX4F3rXGEcSUFIllmrae6iJHW91zS4SNcOocnQoRz1IYnrILYw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.8.tgz",
+      "integrity": "sha512-EEinXtV7MvzWt1dgqnkfUaxCwPnSo3ZeWQzTpppCZFkM9hn+kfViTig2aS1aoXvwi/SsDZ51DDs4st8xr4yqhQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1455,25 +1444,25 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-android-arm-eabi": "1.3.3",
-        "@swc/core-android-arm64": "1.3.3",
-        "@swc/core-darwin-arm64": "1.3.3",
-        "@swc/core-darwin-x64": "1.3.3",
-        "@swc/core-freebsd-x64": "1.3.3",
-        "@swc/core-linux-arm-gnueabihf": "1.3.3",
-        "@swc/core-linux-arm64-gnu": "1.3.3",
-        "@swc/core-linux-arm64-musl": "1.3.3",
-        "@swc/core-linux-x64-gnu": "1.3.3",
-        "@swc/core-linux-x64-musl": "1.3.3",
-        "@swc/core-win32-arm64-msvc": "1.3.3",
-        "@swc/core-win32-ia32-msvc": "1.3.3",
-        "@swc/core-win32-x64-msvc": "1.3.3"
+        "@swc/core-android-arm-eabi": "1.3.8",
+        "@swc/core-android-arm64": "1.3.8",
+        "@swc/core-darwin-arm64": "1.3.8",
+        "@swc/core-darwin-x64": "1.3.8",
+        "@swc/core-freebsd-x64": "1.3.8",
+        "@swc/core-linux-arm-gnueabihf": "1.3.8",
+        "@swc/core-linux-arm64-gnu": "1.3.8",
+        "@swc/core-linux-arm64-musl": "1.3.8",
+        "@swc/core-linux-x64-gnu": "1.3.8",
+        "@swc/core-linux-x64-musl": "1.3.8",
+        "@swc/core-win32-arm64-msvc": "1.3.8",
+        "@swc/core-win32-ia32-msvc": "1.3.8",
+        "@swc/core-win32-x64-msvc": "1.3.8"
       }
     },
     "node_modules/@swc/core-android-arm-eabi": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.3.tgz",
-      "integrity": "sha512-R6MpKXvNx/T/8a0wUTiX1THxfRbURSCmYlSi/JnUaqLYUclQK1N8aCMWz7EYSz6FE0VZBREJYDJcdnfP88E/1Q==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.8.tgz",
+      "integrity": "sha512-7SKRmfT21Iwy1UJVirS89KO1YqA/nYeG6Te97Vi50e0Ua1XmmogE+ooUg4CNk0wevtVmgB3AHXK/1/ak6qY/Ag==",
       "cpu": [
         "arm"
       ],
@@ -1490,9 +1479,9 @@
       }
     },
     "node_modules/@swc/core-android-arm64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.3.tgz",
-      "integrity": "sha512-yZlku4ypVKykwHTS8CETxw2PH23UBeM6VhNB8efF4A4gVWtRZjv1PfjsSqh/X0vjgVTrs2zSaQ+eF6GLVbWrgA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.8.tgz",
+      "integrity": "sha512-K7PwYMOukAFUWR1f1xukNhQXpCWjYfOnBA130hdovuW7J+cxYX2O8L5cKW+VOmlTNXU561+k0jNSO5NkJ4pSSQ==",
       "cpu": [
         "arm64"
       ],
@@ -1516,9 +1505,9 @@
       "optional": true
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.3.tgz",
-      "integrity": "sha512-/T8vyikY7t/be6bHd1D9J/bmXYMDMkBo9NA3auDT/hmouzawhJ6E7OqRE4HLuLTflnRw8WmEWgpeRIzMHvNjBQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.8.tgz",
+      "integrity": "sha512-sEynC48HWwYQ2RzJxBejnWfRQkl65f1+fWNjSWqAIii7I+fJT5La98hJrg+5dfZROBs34g1Zxt8+2Gttm25Nmg==",
       "cpu": [
         "arm64"
       ],
@@ -1532,9 +1521,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.3.tgz",
-      "integrity": "sha512-hw4o1If986In5m3y3/OimgiBKJh49kbTG9MRWo8msqTic2aBlrtfHjSecMn1g+oP7pdaUUCTkovmT7OpvvQ/Tw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.8.tgz",
+      "integrity": "sha512-yimEqFZpmXU6uTnSw1A6umKBN1B68I+Cbl/q4IHm3Z3B9a/aymiQ7lJNrYYEHOgfpHLka4SWwvdSBSrpMczDfg==",
       "cpu": [
         "x64"
       ],
@@ -1548,9 +1537,9 @@
       }
     },
     "node_modules/@swc/core-freebsd-x64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.3.tgz",
-      "integrity": "sha512-JFDu3uLa0WMw77o+QNR5D1uErQ5s18HmEwJr5ndOQoDlS+XO2qUG6AxU5LdwLEl5qMf2C99t7gkfzcCZG1PRsw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.8.tgz",
+      "integrity": "sha512-kGGDDrKVCoM2A8lAJ3jFiWuafxtFxMmvkGlo72GikZsFDHibqr2K2+Ur++nwOz/ZFOf1HJwEbYVbbDa84pSlCw==",
       "cpu": [
         "x64"
       ],
@@ -1574,9 +1563,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.3.tgz",
-      "integrity": "sha512-kJoyNP/ury9KmZnjhpj0QApY6VxC9S4hkgsycm8yTJ23O8WrUbgeDOlgAgFJNyHszhR5CnlssDv7ErCwMZtkgw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.8.tgz",
+      "integrity": "sha512-kLpA6Oei9J7u7NBFT80ziAe3cLhOV7vo/Li9rV44AI8iU6df7KXt7hvzmTyh5gXOg3f98wcMOakFF1FsKvSSdA==",
       "cpu": [
         "arm"
       ],
@@ -1600,9 +1589,9 @@
       "optional": true
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.3.tgz",
-      "integrity": "sha512-Y+10o78O2snKnrNTbasT9S3Out0wlOyAkLZvq5zqzW1cz2K2Yzm04zQdKQOCRHlfTF0XSmZ++qRWVNol49WsNA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.8.tgz",
+      "integrity": "sha512-5W1sAM1lNmDfMy8DzRUiyjubDPZVIvzQRhdsP1zCDE/JKYaDJG8BzeSE6J3VdxNyLfe6tFvJTOCTyNAGWJBiTA==",
       "cpu": [
         "arm64"
       ],
@@ -1616,9 +1605,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.3.tgz",
-      "integrity": "sha512-y6ErPP6Sk0f8exoanUxXeFALvPraTjyoVr8pitpfTqoUd9YcxwOTpPbR5WXI3FWnQ7GS86iH0LvaFDCgHQ1fjg==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.8.tgz",
+      "integrity": "sha512-xdmZX44xzjdG4zqIWEqkZVWukhw1lwVVLjXiQt94GZ9RISpUvanydIzahB/iuI/2/eWP4Stf6vyXn66ay1jIcA==",
       "cpu": [
         "arm64"
       ],
@@ -1632,9 +1621,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.3.tgz",
-      "integrity": "sha512-sqyvNJkPHKHlK/XLIoMNLiux8YxsCJpAk3UreS0NO+sRNRru2AMyrRwX6wxmnJybhEek9SPKF0pXi+GfcaFKYA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.8.tgz",
+      "integrity": "sha512-37YyUxXgLfiILzfoIkbfEB4mRJfWutaY9OThi9H1hLYaXLTfdWkk7bksALK473NY6/Vi/TrjYi1cz+GSteR/nw==",
       "cpu": [
         "x64"
       ],
@@ -1648,9 +1637,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.3.tgz",
-      "integrity": "sha512-5fjwHdMv+DOgEp7sdNVmvS4Hr2rDaewa0BpDW8RefcjHoJnDpFVButLDMkwv/Yd+v4YN+99kyX/lOI+/OTD99w==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.8.tgz",
+      "integrity": "sha512-/MhCGWlIu2rjvUuGKNZSTLUm1jDus2ggmaZpbq87QSA8otPyKB4k5t6ySUzuSTRL8Qk/bLy1xjtjAv2sOzwzJA==",
       "cpu": [
         "x64"
       ],
@@ -1664,9 +1653,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.3.tgz",
-      "integrity": "sha512-JxcfG89GieqCFXkRl/mtFds/ME6ncEtLRIQ0+RBIREIGisA9ZgJ8EryBzGZyPu5+7kE0vXGVB6A2cfrv4SNW4A==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.8.tgz",
+      "integrity": "sha512-UF4BoOtmquKSt5eIODvrimqLLTG30vuIvY8z1/3RJyzCI3uZE3csetmAMvry8ioS1vC5DFETNh4xFO20CJvR0g==",
       "cpu": [
         "arm64"
       ],
@@ -1690,9 +1679,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.3.tgz",
-      "integrity": "sha512-yqZjTn5V7wYCxMCC5Rg8u87SmGeRSlqYAafHL3IgiFe8hSxOykc2dR1MYNc4WZumYiMlU15VSa6mW8A0pj37FA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.8.tgz",
+      "integrity": "sha512-ZsLm+Gimv8RO77AQjkaqs4jncw7AmR5HgR+I6gSRsVhLEo3tRbzSK2br98PRC217RA86Ei148/WUutu9IA7/5g==",
       "cpu": [
         "ia32"
       ],
@@ -1716,9 +1705,9 @@
       "optional": true
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.3.tgz",
-      "integrity": "sha512-CIuxz9wiHkgG7m3kjgptgO3iHOmrybvLf0rUNGbVTTHwTcrpjznAnS/MnMPiaIQPlxz70KSXAR2QJjw7fGtfbA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.8.tgz",
+      "integrity": "sha512-7Kxx6K4hEbwjj3IyD5hqoUGbOtuYJoMUh6ac+gce22oxq4sWWkVRbV0s+oJSXqWA0/PCu07t0m1/B4Z0MpqwuA==",
       "cpu": [
         "x64"
       ],
@@ -1822,9 +1811,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.7.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
-      "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -2039,15 +2028,15 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.3.tgz",
-      "integrity": "sha512-ApPyHSOhS/sVzwUOQIWJmdvDhBsMG01HX9z7ogtkp1TToHGGUWFlnXJUIzCgKPSfiYLn3ibipCYzsKSURHEwLg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.2.0.tgz",
+      "integrity": "sha512-c8FkrW1chgcbyBqOo7jFGpQYfVnb43JqjQGV+C2r94k2rZJOukYOZ6+csAqKE4ms+PHc+yevnONxs27jQIxylw==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.0.3",
+        "@jest/transform": "^29.2.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.0.2",
+        "babel-preset-jest": "^29.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -2076,9 +2065,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
-      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.2.0.tgz",
+      "integrity": "sha512-TnspP2WNiR3GLfCsUNHqeXw0RoQ2f9U5hQ5L3XFpwuO8htQmSrhh8qsB6vi5Yi8+kuynN1yjDjQsPfkebmB6ZA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -2114,12 +2103,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
-      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.2.0.tgz",
+      "integrity": "sha512-z9JmMJppMxNv8N7fNRHvhMg9cvIkMxQBXgFkane3yKVEvEOP+kB50lk8DFRvF9PGqbyXxlmebKWhuDORO8RgdA==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.0.2",
+        "babel-plugin-jest-hoist": "^29.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -2296,9 +2285,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "version": "1.0.30001420",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
+      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2341,9 +2330,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/ci-info": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
-      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
       "dev": true
     },
     "node_modules/cjs-module-lexer": {
@@ -2364,14 +2353,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/co": {
@@ -2443,13 +2435,10 @@
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/corser": {
       "version": "2.0.1",
@@ -2574,9 +2563,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
-      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.2.0.tgz",
+      "integrity": "sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2607,9 +2596,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.262",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
-      "integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw==",
+      "version": "1.4.283",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz",
+      "integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2647,9 +2636,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
-      "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2662,7 +2651,7 @@
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.6",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -2732,14 +2721,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.2",
+        "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -2788,9 +2776,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.31.8",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.8.tgz",
-      "integrity": "sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==",
+      "version": "7.31.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
+      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.5",
@@ -2995,16 +2983,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.3.tgz",
-      "integrity": "sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.2.0.tgz",
+      "integrity": "sha512-03ClF3GWwUqd9Grgkr9ZSdaCJGMRA69PQ8jT7o+Bx100VlGiAFf9/8oIm9Qve7ZVJhuJxFftqFhviZJRxxNfvg==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "@jest/expect-utils": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3873,9 +3861,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -3939,15 +3927,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.0.3.tgz",
-      "integrity": "sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.2.0.tgz",
+      "integrity": "sha512-6krPemKUXCEu5Fh3j6ZVoLMjpTQVm0OCU+7f3K/9gllX8wNIE6NSCQ6s0q2RDoiKLRaQlVRHyscjSPRPqCI0Fg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/core": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.0.3"
+        "jest-cli": "^29.2.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3965,9 +3953,9 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
-      "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.2.0.tgz",
+      "integrity": "sha512-qPVmLLyBmvF5HJrY7krDisx6Voi8DmlV3GZYX0aFNbaQsZeoz1hfxcCMbqDGuQCxU1dJy9eYc2xscE8QrCCYaA==",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
@@ -3978,28 +3966,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.0.3.tgz",
-      "integrity": "sha512-QeGzagC6Hw5pP+df1+aoF8+FBSgkPmraC1UdkeunWh0jmrp7wC0Hr6umdUAOELBQmxtKAOMNC3KAdjmCds92Zg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.2.0.tgz",
+      "integrity": "sha512-bpJRMe+VtvYlF3q8JNx+/cAo4FYvNCiR5s7Z0Scf8aC+KJ2ineSjZKtw1cIZbythlplkiro0My8nc65pfCqJ3A==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.0.3",
-        "@jest/expect": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/expect": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.0.3",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-each": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4008,21 +3996,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.0.3.tgz",
-      "integrity": "sha512-aUy9Gd/Kut1z80eBzG10jAn6BgS3BoBbXyv+uXEqBJ8wnnuZ5RpNfARoskSrTIy1GY4a8f32YGuCMwibtkl9CQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.2.0.tgz",
+      "integrity": "sha512-/581TzbXeO+5kbtSlhXEthGiVJCC8AP0jgT0iZINAAMW+tTFj2uWU7z+HNUH5yIYdHV7AvRr0fWLrmHJGIruHg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/core": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-config": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -4042,31 +4030,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.0.3.tgz",
-      "integrity": "sha512-U5qkc82HHVYe3fNu2CRXLN4g761Na26rWKf7CjM8LlZB3In1jadEkZdMwsE37rd9RSPV0NfYaCjHdk/gu3v+Ew==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.2.0.tgz",
+      "integrity": "sha512-IkdCsrHIoxDPZAyFcdtQrCQ3uftLqns6Joj0tlbxiAQW4k/zTXmIygqWBmPNxO9FbFkDrhtYZiLHXjaJh9rS+Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.0.3",
-        "@jest/types": "^29.0.3",
-        "babel-jest": "^29.0.3",
+        "@jest/test-sequencer": "^29.2.0",
+        "@jest/types": "^29.2.0",
+        "babel-jest": "^29.2.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.0.3",
-        "jest-environment-node": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-runner": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-circus": "^29.2.0",
+        "jest-environment-node": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-runner": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -4087,24 +4075,24 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.3.tgz",
-      "integrity": "sha512-+X/AIF5G/vX9fWK+Db9bi9BQas7M9oBME7egU7psbn4jlszLFCu0dW63UgeE6cs/GANq4fLaT+8sGHQQ0eCUfg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.2.0.tgz",
+      "integrity": "sha512-GsH07qQL+/D/GxlnU+sSg9GL3fBOcuTlmtr3qr2pnkiODCwubNN2/7slW4m3CvxDsEus/VEOfQKRFLyXsUlnZw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.0.0",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "diff-sequences": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
-      "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.2.0.tgz",
+      "integrity": "sha512-bkxUsxTgWQGbXV5IENmfiIuqZhJcyvF7tU4zJ/7ioTutdz4ToB5Yx6JOFBpgI+TphRY4lhOyCWGNH/QFQh5T6A==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -4114,62 +4102,62 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.0.3.tgz",
-      "integrity": "sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.2.0.tgz",
+      "integrity": "sha512-h4LeC3L/R7jIMfTdYowevPIssvcPYQ7Qzs+pCSYsJgPztIizXwKmnfhZXBA4WVqdmvMcpmseYEXb67JT7IJ2eg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.0.0",
-        "jest-util": "^29.0.3",
-        "pretty-format": "^29.0.3"
+        "jest-get-type": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "pretty-format": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.0.3.tgz",
-      "integrity": "sha512-cdZqRCnmIlTXC+9vtvmfiY/40Cj6s2T0czXuq1whvQdmpzAnj4sbqVYuZ4zFHk766xTTJ+Ij3uUqkk8KCfXoyg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.2.0.tgz",
+      "integrity": "sha512-b4qQGVStPMvtZG97Ac0rvnmSIjCZturFU7MQRMp4JDFl7zoaDLTtXmFjFP1tNmi9te6kR8d+Htbv3nYeoaIz6g==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.0.3",
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
-        "jest-mock": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "jest-mock": "^29.2.0",
+        "jest-util": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
-      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.3.tgz",
-      "integrity": "sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.2.0.tgz",
+      "integrity": "sha512-qu9lGFi7qJ8v37egS1phZZUJYiMyWnKwu83NlNT1qs50TbedIX2hFl+9ztsJ7U/ENaHwk1/Bs8fqOIQsScIRwg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -4181,46 +4169,46 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.0.3.tgz",
-      "integrity": "sha512-YfW/G63dAuiuQ3QmQlh8hnqLDe25WFY3eQhuc/Ev1AGmkw5zREblTh7TCSKLoheyggu6G9gxO2hY8p9o6xbaRQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.2.0.tgz",
+      "integrity": "sha512-FXT9sCFdct42+oOqGIr/9kmUw3RbhvpkwidCBT5ySHHoWNGd3c9n7HXpFKjEz9UnUITRCGdn0q2s6Sxrq36kwg==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.3.tgz",
-      "integrity": "sha512-RsR1+cZ6p1hDV4GSCQTg+9qjeotQCgkaleIKLK7dm+U4V/H2bWedU3RAtLm8+mANzZ7eDV33dMar4pejd7047w==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.0.tgz",
+      "integrity": "sha512-FcEfKZ4vm28yCdBsvC69EkrEhcfex+IYlRctNJXsRG9+WC3WxgBNORnECIgqUtj7o/h1d8o7xB/dFUiLi4bqtw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "jest-diff": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.3.tgz",
-      "integrity": "sha512-7T8JiUTtDfppojosORAflABfLsLKMLkBHSWkjNQrjIltGoDzNGn7wEPOSfjqYAGTYME65esQzMJxGDjuLBKdOg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.2.0.tgz",
+      "integrity": "sha512-arBfk5yMFMTnMB22GyG601xGSGthA02vWSewPaxoFo0F9wBqDOyxccPbCcYu8uibw3kduSHXdCOd1PsLSgdomg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4229,13 +4217,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.3.tgz",
-      "integrity": "sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.0.tgz",
+      "integrity": "sha512-aiWGR0P8ivssIO17xkehLGFtCcef2ZwQFNPwEer1jQLHxPctDlIg3Hs6QMq1KpPz5dkCcgM7mwGif4a9IPznlg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
-        "@types/node": "*"
+        "@jest/types": "^29.2.0",
+        "@types/node": "*",
+        "jest-util": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4259,26 +4248,26 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
+      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.0.3.tgz",
-      "integrity": "sha512-toVkia85Y/BPAjJasTC9zIPY6MmVXQPtrCk8SmiheC4MwVFE/CMFlOtMN6jrwPMC6TtNh8+sTMllasFeu1wMPg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.2.0.tgz",
+      "integrity": "sha512-f5c0ljNg2guDBCC7wi92vAhNuA0BtAG5vkY7Fob0c7sUMU1g87mTXqRmjrVFe2XvdwP5m5T/e5KJsCKu9hRvBA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
@@ -4288,13 +4277,13 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.0.3.tgz",
-      "integrity": "sha512-KzuBnXqNvbuCdoJpv8EanbIGObk7vUBNt/PwQPPx2aMhlv/jaXpUJsqWYRpP/0a50faMBY7WFFP8S3/CCzwfDw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.2.0.tgz",
+      "integrity": "sha512-Cd0Z39sDntEnfR9PoUdFHUAGDvtKI0/7Wt73l3lt03A3yQ+A6Qi3XmBuqGjdFl2QbXaPa937oLhilG612P8HGQ==",
       "dev": true,
       "dependencies": {
-        "jest-regex-util": "^29.0.0",
-        "jest-snapshot": "^29.0.3"
+        "jest-regex-util": "^29.2.0",
+        "jest-snapshot": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4318,30 +4307,30 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.0.3.tgz",
-      "integrity": "sha512-Usu6VlTOZlCZoNuh3b2Tv/yzDpKqtiNAetG9t3kJuHfUyVMNW7ipCCJOUojzKkjPoaN7Bl1f7Buu6PE0sGpQxw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.2.0.tgz",
+      "integrity": "sha512-VPBrCwl9fM2mc5yk6yZhNrgXzRJMD5jfLmntkMLlrVq4hQPWbRK998iJlR+DOGCO04TC9PPYLntOJ001Vnf28g==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.0.3",
-        "@jest/environment": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/environment": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.10.2",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.0.0",
-        "jest-environment-node": "^29.0.3",
-        "jest-haste-map": "^29.0.3",
-        "jest-leak-detector": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-resolve": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-watcher": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-docblock": "^29.2.0",
+        "jest-environment-node": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-leak-detector": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-watcher": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -4350,31 +4339,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.0.3.tgz",
-      "integrity": "sha512-12gZXRQ7ozEeEHKTY45a+YLqzNDR/x4c//X6AqwKwKJPpWM8FY4vwn4VQJOcLRS3Nd1fWwgP7LU4SoynhuUMHQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.2.0.tgz",
+      "integrity": "sha512-+GDmzCrswQF+mvI0upTYMe/OPYnlRRNLLDHM9AFLp2y7zxWoDoYgb8DL3WwJ8d9m743AzrnvBV9JQHi/0ed7dg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.0.3",
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/globals": "^29.0.3",
-        "@jest/source-map": "^29.0.0",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/globals": "^29.2.0",
+        "@jest/source-map": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-mock": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-mock": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -4383,9 +4372,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.3.tgz",
-      "integrity": "sha512-52q6JChm04U3deq+mkQ7R/7uy7YyfVIrebMi6ZkBoDJ85yEjm/sJwdr1P0LOIEHmpyLlXrxy3QP0Zf5J2kj0ew==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.2.0.tgz",
+      "integrity": "sha512-YCKrOR0PLRXROmww73fHO9oeY4tL+LPQXWR3yml1+hKbQDR8j1VUrVzB65hKSJJgxBOr1vWx+hmz2by8JjAU5w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4394,23 +4383,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/expect-utils": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.0.3",
+        "expect": "^29.2.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-haste-map": "^29.0.3",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-diff": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -4418,9 +4407,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4433,12 +4422,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.3.tgz",
-      "integrity": "sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.0.tgz",
+      "integrity": "sha512-8M1dx12ujkBbnhwytrezWY0Ut79hbflwodE+qZKjxSRz5qt4xDp6dQQJaOCFvCmE0QJqp9KyEK33lpPNjnhevw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -4450,17 +4439,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.0.3.tgz",
-      "integrity": "sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.2.0.tgz",
+      "integrity": "sha512-4Vl51bPNeFeDok9aJiOnrC6tqJbOp4iMCYlewoC2ZzYJZ5+6pfr3KObAdx5wP8auHcg2MRaguiqj5OdScZa72g==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.0.0",
+        "jest-get-type": "^29.2.0",
         "leven": "^3.1.0",
-        "pretty-format": "^29.0.3"
+        "pretty-format": "^29.2.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4479,18 +4468,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.0.3.tgz",
-      "integrity": "sha512-tQX9lU91A+9tyUQKUMp0Ns8xAcdhC9fo73eqA3LFxP2bSgiF49TNcc+vf3qgGYYK9qRjFpXW9+4RgF/mbxyOOw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.2.0.tgz",
+      "integrity": "sha512-bRh0JdUeN+cl9XfK7tMnXLm4Mv70hG2SZlqbkFe5CTs7oeCkbwlGBk/mEfEJ63mrxZ8LPbnfaMpfSmkhEQBEGA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.10.2",
-        "jest-util": "^29.0.3",
+        "jest-util": "^29.2.0",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -4498,12 +4487,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.3.tgz",
-      "integrity": "sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.0.tgz",
+      "integrity": "sha512-mluOlMbRX1H59vGVzPcVg2ALfCausbBpxC8a2KWOzInhYHZibbHH8CB0C1JkmkpfurrkOYgF7FPmypuom1OM9A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
+        "jest-util": "^29.2.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -4527,9 +4517,9 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "node_modules/js-tokens": {
@@ -4787,9 +4777,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -4891,9 +4884,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
-      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
+      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -4902,9 +4895,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5310,9 +5303,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
-      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -5403,9 +5396,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.3.tgz",
-      "integrity": "sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.2.0.tgz",
+      "integrity": "sha512-QCSUFdwOi924g24czhOH5eTkXxUCqlLGZBRCySlwDYHIXRJkdGyjJc9nZaqhlFBZws8dq5Dvk0lCilsmlfsPxw==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.0.0",
@@ -5775,9 +5768,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.0.tgz",
-      "integrity": "sha512-ft96f8WzGxavg0rkLpMw90MTPMUZDyf0tHjPPh8Ob59xt6KzX8EqtotcqZGUm7kwqpX2pmYiyYX2LL0IZ/FDEw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -5797,9 +5790,9 @@
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6159,19 +6152,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6208,22 +6188,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -6324,9 +6288,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6363,9 +6327,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "funding": [
         {
@@ -6542,12 +6506,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dev": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
@@ -6602,27 +6566,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
-      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
+      "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
+      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.1",
+        "@babel/generator": "^7.19.3",
+        "@babel/helper-compilation-targets": "^7.19.3",
         "@babel/helper-module-transforms": "^7.19.0",
         "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.1",
+        "@babel/parser": "^7.19.3",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/traverse": "^7.19.3",
+        "@babel/types": "^7.19.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6631,12 +6595,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
-      "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
+      "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.0",
+        "@babel/types": "^7.19.4",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -6655,12 +6619,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
-      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
+      "version": "7.19.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
+      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.1",
+        "@babel/compat-data": "^7.19.3",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "semver": "^6.3.0"
@@ -6723,12 +6687,12 @@
       "dev": true
     },
     "@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
+      "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.19.4"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -6741,9 +6705,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
@@ -6759,14 +6723,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
+      "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/traverse": "^7.19.4",
+        "@babel/types": "^7.19.4"
       }
     },
     "@babel/highlight": {
@@ -6839,9 +6803,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
-      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
+      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -6982,19 +6946,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
-      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
+      "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
+        "@babel/generator": "^7.19.4",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.1",
-        "@babel/types": "^7.19.0",
+        "@babel/parser": "^7.19.4",
+        "@babel/types": "^7.19.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -7008,13 +6972,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
+      "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -7025,9 +6989,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -7042,21 +7006,15 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
-      "integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
-    },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -7154,123 +7112,123 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.0.3.tgz",
-      "integrity": "sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.2.0.tgz",
+      "integrity": "sha512-Xz1Wu+ZZxcB3RS8U3HdkFxlRJ7kLXI/by9X7d2/gvseIWPwYu/c1EsYy77cB5iyyHGOy3whS2HycjcuzIF4Jow==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.0.3.tgz",
-      "integrity": "sha512-1d0hLbOrM1qQE3eP3DtakeMbKTcXiXP3afWxqz103xPyddS2NhnNghS7MaXx1dcDt4/6p4nlhmeILo2ofgi8cQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.2.0.tgz",
+      "integrity": "sha512-+gyJ3bX+kGEW/eqt/0kI7fLjqiFr3AN8O+rlEl1fYRf7D8h4Sj4tBGo9YOSirvWgvemoH2EPRya35bgvcPFzHQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.0.3",
-        "@jest/reporters": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/reporters": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.0.0",
-        "jest-config": "^29.0.3",
-        "jest-haste-map": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-resolve-dependencies": "^29.0.3",
-        "jest-runner": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
-        "jest-watcher": "^29.0.3",
+        "jest-changed-files": "^29.2.0",
+        "jest-config": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-resolve-dependencies": "^29.2.0",
+        "jest-runner": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
+        "jest-watcher": "^29.2.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
     },
     "@jest/environment": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.0.3.tgz",
-      "integrity": "sha512-iKl272NKxYNQNqXMQandAIwjhQaGw5uJfGXduu8dS9llHi8jV2ChWrtOAVPnMbaaoDhnI3wgUGNDvZgHeEJQCA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.2.0.tgz",
+      "integrity": "sha512-foaVv1QVPB31Mno3LlL58PxEQQOLZd9zQfCpyQQCQIpUAtdFP1INBjkphxrCfKT13VxpA0z5jFGIkmZk0DAg2Q==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
-        "jest-mock": "^29.0.3"
+        "jest-mock": "^29.2.0"
       }
     },
     "@jest/expect": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.0.3.tgz",
-      "integrity": "sha512-6W7K+fsI23FQ01H/BWccPyDZFrnU9QlzDcKOjrNVU5L8yUORFAJJIpmyxWPW70+X624KUNqzZwPThPMX28aXEQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.2.0.tgz",
+      "integrity": "sha512-+3lxcYL9e0xPJGOR33utxxejn+Mulz40kY0oy0FVsmIESW87NZDJ7B1ovaIqeX0xIgPX4laS5SGlqD2uSoBMcw==",
       "dev": true,
       "requires": {
-        "expect": "^29.0.3",
-        "jest-snapshot": "^29.0.3"
+        "expect": "^29.2.0",
+        "jest-snapshot": "^29.2.0"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.0.3.tgz",
-      "integrity": "sha512-i1xUkau7K/63MpdwiRqaxgZOjxYs4f0WMTGJnYwUKubsNRZSeQbLorS7+I4uXVF9KQ5r61BUPAUMZ7Lf66l64Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.2.0.tgz",
+      "integrity": "sha512-nz2IDF7nb1qmj9hx8Ja3MFab2q9Ml8QbOaaeJNyX5JQJHU8QUvEDiMctmhGEkk3Kzr8w8vAqz4hPk/ogJSrUhg==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.0.0"
+        "jest-get-type": "^29.2.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.0.3.tgz",
-      "integrity": "sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.2.0.tgz",
+      "integrity": "sha512-mX0V0uQsgeSLTt0yTqanAhhpeUKMGd2uq+PSLAfO40h72bvfNNQ7pIEl9vIwNMFxRih1ENveEjSBsLjxGGDPSw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@sinonjs/fake-timers": "^9.1.2",
         "@types/node": "*",
-        "jest-message-util": "^29.0.3",
-        "jest-mock": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "jest-message-util": "^29.2.0",
+        "jest-mock": "^29.2.0",
+        "jest-util": "^29.2.0"
       }
     },
     "@jest/globals": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.0.3.tgz",
-      "integrity": "sha512-YqGHT65rFY2siPIHHFjuCGUsbzRjdqkwbat+Of6DmYRg5shIXXrLdZoVE/+TJ9O1dsKsFmYhU58JvIbZRU1Z9w==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.2.0.tgz",
+      "integrity": "sha512-JQxtEVNWiai1p3PIzAJZSyEqQdAJGvNKvinZDPfu0mhiYEVx6E+PiBuDWj1sVUW8hzu+R3DVqaWC9K2xcLRIAA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.0.3",
-        "@jest/expect": "^29.0.3",
-        "@jest/types": "^29.0.3",
-        "jest-mock": "^29.0.3"
+        "@jest/environment": "^29.2.0",
+        "@jest/expect": "^29.2.0",
+        "@jest/types": "^29.2.0",
+        "jest-mock": "^29.2.0"
       }
     },
     "@jest/reporters": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.0.3.tgz",
-      "integrity": "sha512-3+QU3d4aiyOWfmk1obDerie4XNCaD5Xo1IlKNde2yGEi02WQD+ZQD0i5Hgqm1e73sMV7kw6pMlCnprtEwEVwxw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.2.0.tgz",
+      "integrity": "sha512-BXoAJatxTZ18U0cwD7C8qBo8V6vef8AXYRBZdhqE5DF9CmpqmhMfw9c7OUvYqMTnBBK9A0NgXGO4Lc9EJzdHvw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -7283,13 +7241,12 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
-        "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^9.0.1"
       }
     },
@@ -7303,9 +7260,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
-      "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.2.0.tgz",
+      "integrity": "sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -7314,46 +7271,46 @@
       }
     },
     "@jest/test-result": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.0.3.tgz",
-      "integrity": "sha512-vViVnQjCgTmbhDKEonKJPtcFe9G/CJO4/Np4XwYJah+lF2oI7KKeRp8t1dFvv44wN2NdbDb/qC6pi++Vpp0Dlg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.2.0.tgz",
+      "integrity": "sha512-l76EPJ6QqtzsCLS4aimJqWO53pxZ82o3aE+Brcmo1HJ/phb9+MR7gPhyDdN6VSGaLJCRVJBZgWEhAEz+qON0Fw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.0.3.tgz",
-      "integrity": "sha512-Hf4+xYSWZdxTNnhDykr8JBs0yBN/nxOXyUQWfotBUqqy0LF9vzcFB0jm/EDNZCx587znLWTIgxcokW7WeZMobQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.2.0.tgz",
+      "integrity": "sha512-NCnjZcGnVdva6IDqF7TCuFsXs2F1tohiNF9sasSJNzD7VfN5ic9XgcS/oPDalGiPLxCmGKj4kewqqrKAqBACcQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.0.3",
+        "@jest/test-result": "^29.2.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
         "slash": "^3.0.0"
       }
     },
     "@jest/transform": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.3.tgz",
-      "integrity": "sha512-C5ihFTRYaGDbi/xbRQRdbo5ddGtI4VSpmL6AIcZxdhwLbXMa7PcXxxqyI91vGOFHnn5aVM3WYnYKCHEqmLVGzg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.2.0.tgz",
+      "integrity": "sha512-NXMujGHy+B4DAj4dGnVPD0SIXlR2Z/N8Gp9h3mF66kcIRult1WWqY3/CEIrJcKviNWaFPYhZjCG2L3fteWzcUw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -7361,9 +7318,9 @@
       }
     },
     "@jest/types": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.3.tgz",
-      "integrity": "sha512-coBJmOQvurXjN1Hh5PzF7cmsod0zLIOXpP8KD161mqNlroMhLcwpODiEzi7ZsRl5Z/AIuxpeNm8DCl43F4kz8A==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.0.tgz",
+      "integrity": "sha512-mfgpQz4Z2xGo37m6KD8xEpKelaVzvYVRijmLPePn9pxgaPEtX+SqIyPNzzoeCPXKYbB4L/wYSgXDL8o3Gop78Q==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.0.0",
@@ -7403,13 +7360,13 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@next/env": {
@@ -7536,19 +7493,19 @@
       }
     },
     "@playwright/test": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
-      "integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.26.0"
+        "playwright-core": "1.27.1"
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.43",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.43.tgz",
-      "integrity": "sha512-1orQTvtazZmsPeBroJjysvsOQCYV2yjWlebkSY38pl5vr2tdLjEJ+LoxITlGNZaH2RE19WlAwQMkH/7C14wLfw==",
+      "version": "0.24.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.46.tgz",
+      "integrity": "sha512-ng4ut1z2MCBhK/NwDVwIQp3pAUOCs/KNaW3cBxdFB2xTDrOuo1xuNmpr/9HHFhxqIvHrs1NTH3KJg6q+JSy1Kw==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -7582,30 +7539,30 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.3.tgz",
-      "integrity": "sha512-OGx3Qpw+czNSaea1ojP2X2wxrGtYicQxH1QnzX4F3rXGEcSUFIllmrae6iJHW91zS4SNcOocnQoRz1IYnrILYw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.8.tgz",
+      "integrity": "sha512-EEinXtV7MvzWt1dgqnkfUaxCwPnSo3ZeWQzTpppCZFkM9hn+kfViTig2aS1aoXvwi/SsDZ51DDs4st8xr4yqhQ==",
       "dev": true,
       "requires": {
-        "@swc/core-android-arm-eabi": "1.3.3",
-        "@swc/core-android-arm64": "1.3.3",
-        "@swc/core-darwin-arm64": "1.3.3",
-        "@swc/core-darwin-x64": "1.3.3",
-        "@swc/core-freebsd-x64": "1.3.3",
-        "@swc/core-linux-arm-gnueabihf": "1.3.3",
-        "@swc/core-linux-arm64-gnu": "1.3.3",
-        "@swc/core-linux-arm64-musl": "1.3.3",
-        "@swc/core-linux-x64-gnu": "1.3.3",
-        "@swc/core-linux-x64-musl": "1.3.3",
-        "@swc/core-win32-arm64-msvc": "1.3.3",
-        "@swc/core-win32-ia32-msvc": "1.3.3",
-        "@swc/core-win32-x64-msvc": "1.3.3"
+        "@swc/core-android-arm-eabi": "1.3.8",
+        "@swc/core-android-arm64": "1.3.8",
+        "@swc/core-darwin-arm64": "1.3.8",
+        "@swc/core-darwin-x64": "1.3.8",
+        "@swc/core-freebsd-x64": "1.3.8",
+        "@swc/core-linux-arm-gnueabihf": "1.3.8",
+        "@swc/core-linux-arm64-gnu": "1.3.8",
+        "@swc/core-linux-arm64-musl": "1.3.8",
+        "@swc/core-linux-x64-gnu": "1.3.8",
+        "@swc/core-linux-x64-musl": "1.3.8",
+        "@swc/core-win32-arm64-msvc": "1.3.8",
+        "@swc/core-win32-ia32-msvc": "1.3.8",
+        "@swc/core-win32-x64-msvc": "1.3.8"
       }
     },
     "@swc/core-android-arm-eabi": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.3.tgz",
-      "integrity": "sha512-R6MpKXvNx/T/8a0wUTiX1THxfRbURSCmYlSi/JnUaqLYUclQK1N8aCMWz7EYSz6FE0VZBREJYDJcdnfP88E/1Q==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.8.tgz",
+      "integrity": "sha512-7SKRmfT21Iwy1UJVirS89KO1YqA/nYeG6Te97Vi50e0Ua1XmmogE+ooUg4CNk0wevtVmgB3AHXK/1/ak6qY/Ag==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7613,9 +7570,9 @@
       }
     },
     "@swc/core-android-arm64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.3.tgz",
-      "integrity": "sha512-yZlku4ypVKykwHTS8CETxw2PH23UBeM6VhNB8efF4A4gVWtRZjv1PfjsSqh/X0vjgVTrs2zSaQ+eF6GLVbWrgA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.8.tgz",
+      "integrity": "sha512-K7PwYMOukAFUWR1f1xukNhQXpCWjYfOnBA130hdovuW7J+cxYX2O8L5cKW+VOmlTNXU561+k0jNSO5NkJ4pSSQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7632,23 +7589,23 @@
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.3.tgz",
-      "integrity": "sha512-/T8vyikY7t/be6bHd1D9J/bmXYMDMkBo9NA3auDT/hmouzawhJ6E7OqRE4HLuLTflnRw8WmEWgpeRIzMHvNjBQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.8.tgz",
+      "integrity": "sha512-sEynC48HWwYQ2RzJxBejnWfRQkl65f1+fWNjSWqAIii7I+fJT5La98hJrg+5dfZROBs34g1Zxt8+2Gttm25Nmg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.3.tgz",
-      "integrity": "sha512-hw4o1If986In5m3y3/OimgiBKJh49kbTG9MRWo8msqTic2aBlrtfHjSecMn1g+oP7pdaUUCTkovmT7OpvvQ/Tw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.8.tgz",
+      "integrity": "sha512-yimEqFZpmXU6uTnSw1A6umKBN1B68I+Cbl/q4IHm3Z3B9a/aymiQ7lJNrYYEHOgfpHLka4SWwvdSBSrpMczDfg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-freebsd-x64": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.3.tgz",
-      "integrity": "sha512-JFDu3uLa0WMw77o+QNR5D1uErQ5s18HmEwJr5ndOQoDlS+XO2qUG6AxU5LdwLEl5qMf2C99t7gkfzcCZG1PRsw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.8.tgz",
+      "integrity": "sha512-kGGDDrKVCoM2A8lAJ3jFiWuafxtFxMmvkGlo72GikZsFDHibqr2K2+Ur++nwOz/ZFOf1HJwEbYVbbDa84pSlCw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7665,9 +7622,9 @@
       }
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.3.tgz",
-      "integrity": "sha512-kJoyNP/ury9KmZnjhpj0QApY6VxC9S4hkgsycm8yTJ23O8WrUbgeDOlgAgFJNyHszhR5CnlssDv7ErCwMZtkgw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.8.tgz",
+      "integrity": "sha512-kLpA6Oei9J7u7NBFT80ziAe3cLhOV7vo/Li9rV44AI8iU6df7KXt7hvzmTyh5gXOg3f98wcMOakFF1FsKvSSdA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7684,37 +7641,37 @@
       }
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.3.tgz",
-      "integrity": "sha512-Y+10o78O2snKnrNTbasT9S3Out0wlOyAkLZvq5zqzW1cz2K2Yzm04zQdKQOCRHlfTF0XSmZ++qRWVNol49WsNA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.8.tgz",
+      "integrity": "sha512-5W1sAM1lNmDfMy8DzRUiyjubDPZVIvzQRhdsP1zCDE/JKYaDJG8BzeSE6J3VdxNyLfe6tFvJTOCTyNAGWJBiTA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.3.tgz",
-      "integrity": "sha512-y6ErPP6Sk0f8exoanUxXeFALvPraTjyoVr8pitpfTqoUd9YcxwOTpPbR5WXI3FWnQ7GS86iH0LvaFDCgHQ1fjg==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.8.tgz",
+      "integrity": "sha512-xdmZX44xzjdG4zqIWEqkZVWukhw1lwVVLjXiQt94GZ9RISpUvanydIzahB/iuI/2/eWP4Stf6vyXn66ay1jIcA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.3.tgz",
-      "integrity": "sha512-sqyvNJkPHKHlK/XLIoMNLiux8YxsCJpAk3UreS0NO+sRNRru2AMyrRwX6wxmnJybhEek9SPKF0pXi+GfcaFKYA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.8.tgz",
+      "integrity": "sha512-37YyUxXgLfiILzfoIkbfEB4mRJfWutaY9OThi9H1hLYaXLTfdWkk7bksALK473NY6/Vi/TrjYi1cz+GSteR/nw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.3.tgz",
-      "integrity": "sha512-5fjwHdMv+DOgEp7sdNVmvS4Hr2rDaewa0BpDW8RefcjHoJnDpFVButLDMkwv/Yd+v4YN+99kyX/lOI+/OTD99w==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.8.tgz",
+      "integrity": "sha512-/MhCGWlIu2rjvUuGKNZSTLUm1jDus2ggmaZpbq87QSA8otPyKB4k5t6ySUzuSTRL8Qk/bLy1xjtjAv2sOzwzJA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.3.tgz",
-      "integrity": "sha512-JxcfG89GieqCFXkRl/mtFds/ME6ncEtLRIQ0+RBIREIGisA9ZgJ8EryBzGZyPu5+7kE0vXGVB6A2cfrv4SNW4A==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.8.tgz",
+      "integrity": "sha512-UF4BoOtmquKSt5eIODvrimqLLTG30vuIvY8z1/3RJyzCI3uZE3csetmAMvry8ioS1vC5DFETNh4xFO20CJvR0g==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7731,9 +7688,9 @@
       }
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.3.tgz",
-      "integrity": "sha512-yqZjTn5V7wYCxMCC5Rg8u87SmGeRSlqYAafHL3IgiFe8hSxOykc2dR1MYNc4WZumYiMlU15VSa6mW8A0pj37FA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.8.tgz",
+      "integrity": "sha512-ZsLm+Gimv8RO77AQjkaqs4jncw7AmR5HgR+I6gSRsVhLEo3tRbzSK2br98PRC217RA86Ei148/WUutu9IA7/5g==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7750,9 +7707,9 @@
       }
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.3.tgz",
-      "integrity": "sha512-CIuxz9wiHkgG7m3kjgptgO3iHOmrybvLf0rUNGbVTTHwTcrpjznAnS/MnMPiaIQPlxz70KSXAR2QJjw7fGtfbA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.8.tgz",
+      "integrity": "sha512-7Kxx6K4hEbwjj3IyD5hqoUGbOtuYJoMUh6ac+gce22oxq4sWWkVRbV0s+oJSXqWA0/PCu07t0m1/B4Z0MpqwuA==",
       "dev": true,
       "optional": true
     },
@@ -7847,9 +7804,9 @@
       }
     },
     "@types/node": {
-      "version": "18.7.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
-      "integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "@types/prettier": {
@@ -8015,15 +7972,15 @@
       }
     },
     "babel-jest": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.3.tgz",
-      "integrity": "sha512-ApPyHSOhS/sVzwUOQIWJmdvDhBsMG01HX9z7ogtkp1TToHGGUWFlnXJUIzCgKPSfiYLn3ibipCYzsKSURHEwLg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.2.0.tgz",
+      "integrity": "sha512-c8FkrW1chgcbyBqOo7jFGpQYfVnb43JqjQGV+C2r94k2rZJOukYOZ6+csAqKE4ms+PHc+yevnONxs27jQIxylw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^29.0.3",
+        "@jest/transform": "^29.2.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.0.2",
+        "babel-preset-jest": "^29.2.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -8043,9 +8000,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
-      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.2.0.tgz",
+      "integrity": "sha512-TnspP2WNiR3GLfCsUNHqeXw0RoQ2f9U5hQ5L3XFpwuO8htQmSrhh8qsB6vi5Yi8+kuynN1yjDjQsPfkebmB6ZA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -8075,12 +8032,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
-      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.2.0.tgz",
+      "integrity": "sha512-z9JmMJppMxNv8N7fNRHvhMg9cvIkMxQBXgFkane3yKVEvEOP+kB50lk8DFRvF9PGqbyXxlmebKWhuDORO8RgdA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^29.0.2",
+        "babel-plugin-jest-hoist": "^29.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -8192,9 +8149,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001412",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
-      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA=="
+      "version": "1.0.30001420",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
+      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -8218,9 +8175,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "ci-info": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
-      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -8238,13 +8195,13 @@
       }
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -8304,13 +8261,10 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "corser": {
       "version": "2.0.1",
@@ -8397,9 +8351,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
-      "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.2.0.tgz",
+      "integrity": "sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==",
       "dev": true
     },
     "dir-glob": {
@@ -8421,9 +8375,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.262",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.262.tgz",
-      "integrity": "sha512-Ckn5haqmGh/xS8IbcgK3dnwAVnhDyo/WQnklWn6yaMucYTq7NNxwlGE8ElzEOnonzRLzUCo2Ot3vUb2GYUF2Hw==",
+      "version": "1.4.283",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz",
+      "integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==",
       "dev": true
     },
     "emittery": {
@@ -8455,9 +8409,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
-      "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+      "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -8470,7 +8424,7 @@
         "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.6",
+        "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -8519,14 +8473,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.2",
+        "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -8566,9 +8519,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.31.8",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.8.tgz",
-      "integrity": "sha512-5lBTZmgQmARLLSYiwI71tiGVTLUuqXantZM6vlSY39OaDSV0M7+32K5DnLkmFrwTe+Ksz0ffuLUC91RUviVZfw==",
+      "version": "7.31.10",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
+      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.5",
@@ -8713,16 +8666,16 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "expect": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.0.3.tgz",
-      "integrity": "sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.2.0.tgz",
+      "integrity": "sha512-03ClF3GWwUqd9Grgkr9ZSdaCJGMRA69PQ8jT7o+Bx100VlGiAFf9/8oIm9Qve7ZVJhuJxFftqFhviZJRxxNfvg==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "@jest/expect-utils": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0"
       }
     },
     "fast-deep-equal": {
@@ -9327,9 +9280,9 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",
@@ -9380,21 +9333,21 @@
       }
     },
     "jest": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.0.3.tgz",
-      "integrity": "sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.2.0.tgz",
+      "integrity": "sha512-6krPemKUXCEu5Fh3j6ZVoLMjpTQVm0OCU+7f3K/9gllX8wNIE6NSCQ6s0q2RDoiKLRaQlVRHyscjSPRPqCI0Fg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/core": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.0.3"
+        "jest-cli": "^29.2.0"
       }
     },
     "jest-changed-files": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
-      "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.2.0.tgz",
+      "integrity": "sha512-qPVmLLyBmvF5HJrY7krDisx6Voi8DmlV3GZYX0aFNbaQsZeoz1hfxcCMbqDGuQCxU1dJy9eYc2xscE8QrCCYaA==",
       "dev": true,
       "requires": {
         "execa": "^5.0.0",
@@ -9402,203 +9355,204 @@
       }
     },
     "jest-circus": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.0.3.tgz",
-      "integrity": "sha512-QeGzagC6Hw5pP+df1+aoF8+FBSgkPmraC1UdkeunWh0jmrp7wC0Hr6umdUAOELBQmxtKAOMNC3KAdjmCds92Zg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.2.0.tgz",
+      "integrity": "sha512-bpJRMe+VtvYlF3q8JNx+/cAo4FYvNCiR5s7Z0Scf8aC+KJ2ineSjZKtw1cIZbythlplkiro0My8nc65pfCqJ3A==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.0.3",
-        "@jest/expect": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/expect": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.0.3",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-each": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-cli": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.0.3.tgz",
-      "integrity": "sha512-aUy9Gd/Kut1z80eBzG10jAn6BgS3BoBbXyv+uXEqBJ8wnnuZ5RpNfARoskSrTIy1GY4a8f32YGuCMwibtkl9CQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.2.0.tgz",
+      "integrity": "sha512-/581TzbXeO+5kbtSlhXEthGiVJCC8AP0jgT0iZINAAMW+tTFj2uWU7z+HNUH5yIYdHV7AvRr0fWLrmHJGIruHg==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/core": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-config": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       }
     },
     "jest-config": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.0.3.tgz",
-      "integrity": "sha512-U5qkc82HHVYe3fNu2CRXLN4g761Na26rWKf7CjM8LlZB3In1jadEkZdMwsE37rd9RSPV0NfYaCjHdk/gu3v+Ew==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.2.0.tgz",
+      "integrity": "sha512-IkdCsrHIoxDPZAyFcdtQrCQ3uftLqns6Joj0tlbxiAQW4k/zTXmIygqWBmPNxO9FbFkDrhtYZiLHXjaJh9rS+Q==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.0.3",
-        "@jest/types": "^29.0.3",
-        "babel-jest": "^29.0.3",
+        "@jest/test-sequencer": "^29.2.0",
+        "@jest/types": "^29.2.0",
+        "babel-jest": "^29.2.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.0.3",
-        "jest-environment-node": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-runner": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-circus": "^29.2.0",
+        "jest-environment-node": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-runner": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       }
     },
     "jest-diff": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.0.3.tgz",
-      "integrity": "sha512-+X/AIF5G/vX9fWK+Db9bi9BQas7M9oBME7egU7psbn4jlszLFCu0dW63UgeE6cs/GANq4fLaT+8sGHQQ0eCUfg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.2.0.tgz",
+      "integrity": "sha512-GsH07qQL+/D/GxlnU+sSg9GL3fBOcuTlmtr3qr2pnkiODCwubNN2/7slW4m3CvxDsEus/VEOfQKRFLyXsUlnZw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.0.0",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "diff-sequences": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       }
     },
     "jest-docblock": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
-      "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.2.0.tgz",
+      "integrity": "sha512-bkxUsxTgWQGbXV5IENmfiIuqZhJcyvF7tU4zJ/7ioTutdz4ToB5Yx6JOFBpgI+TphRY4lhOyCWGNH/QFQh5T6A==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.0.3.tgz",
-      "integrity": "sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.2.0.tgz",
+      "integrity": "sha512-h4LeC3L/R7jIMfTdYowevPIssvcPYQ7Qzs+pCSYsJgPztIizXwKmnfhZXBA4WVqdmvMcpmseYEXb67JT7IJ2eg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.0.0",
-        "jest-util": "^29.0.3",
-        "pretty-format": "^29.0.3"
+        "jest-get-type": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "pretty-format": "^29.2.0"
       }
     },
     "jest-environment-node": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.0.3.tgz",
-      "integrity": "sha512-cdZqRCnmIlTXC+9vtvmfiY/40Cj6s2T0czXuq1whvQdmpzAnj4sbqVYuZ4zFHk766xTTJ+Ij3uUqkk8KCfXoyg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.2.0.tgz",
+      "integrity": "sha512-b4qQGVStPMvtZG97Ac0rvnmSIjCZturFU7MQRMp4JDFl7zoaDLTtXmFjFP1tNmi9te6kR8d+Htbv3nYeoaIz6g==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.0.3",
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
-        "jest-mock": "^29.0.3",
-        "jest-util": "^29.0.3"
+        "jest-mock": "^29.2.0",
+        "jest-util": "^29.2.0"
       }
     },
     "jest-get-type": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
-      "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.3.tgz",
-      "integrity": "sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.2.0.tgz",
+      "integrity": "sha512-qu9lGFi7qJ8v37egS1phZZUJYiMyWnKwu83NlNT1qs50TbedIX2hFl+9ztsJ7U/ENaHwk1/Bs8fqOIQsScIRwg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-regex-util": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
     },
     "jest-leak-detector": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.0.3.tgz",
-      "integrity": "sha512-YfW/G63dAuiuQ3QmQlh8hnqLDe25WFY3eQhuc/Ev1AGmkw5zREblTh7TCSKLoheyggu6G9gxO2hY8p9o6xbaRQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.2.0.tgz",
+      "integrity": "sha512-FXT9sCFdct42+oOqGIr/9kmUw3RbhvpkwidCBT5ySHHoWNGd3c9n7HXpFKjEz9UnUITRCGdn0q2s6Sxrq36kwg==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.0.3.tgz",
-      "integrity": "sha512-RsR1+cZ6p1hDV4GSCQTg+9qjeotQCgkaleIKLK7dm+U4V/H2bWedU3RAtLm8+mANzZ7eDV33dMar4pejd7047w==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.0.tgz",
+      "integrity": "sha512-FcEfKZ4vm28yCdBsvC69EkrEhcfex+IYlRctNJXsRG9+WC3WxgBNORnECIgqUtj7o/h1d8o7xB/dFUiLi4bqtw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "pretty-format": "^29.0.3"
+        "jest-diff": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.0"
       }
     },
     "jest-message-util": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.0.3.tgz",
-      "integrity": "sha512-7T8JiUTtDfppojosORAflABfLsLKMLkBHSWkjNQrjIltGoDzNGn7wEPOSfjqYAGTYME65esQzMJxGDjuLBKdOg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.2.0.tgz",
+      "integrity": "sha512-arBfk5yMFMTnMB22GyG601xGSGthA02vWSewPaxoFo0F9wBqDOyxccPbCcYu8uibw3kduSHXdCOd1PsLSgdomg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-mock": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.0.3.tgz",
-      "integrity": "sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.2.0.tgz",
+      "integrity": "sha512-aiWGR0P8ivssIO17xkehLGFtCcef2ZwQFNPwEer1jQLHxPctDlIg3Hs6QMq1KpPz5dkCcgM7mwGif4a9IPznlg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
-        "@types/node": "*"
+        "@jest/types": "^29.2.0",
+        "@types/node": "*",
+        "jest-util": "^29.2.0"
       }
     },
     "jest-pnp-resolver": {
@@ -9609,23 +9563,23 @@
       "requires": {}
     },
     "jest-regex-util": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
+      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.0.3.tgz",
-      "integrity": "sha512-toVkia85Y/BPAjJasTC9zIPY6MmVXQPtrCk8SmiheC4MwVFE/CMFlOtMN6jrwPMC6TtNh8+sTMllasFeu1wMPg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.2.0.tgz",
+      "integrity": "sha512-f5c0ljNg2guDBCC7wi92vAhNuA0BtAG5vkY7Fob0c7sUMU1g87mTXqRmjrVFe2XvdwP5m5T/e5KJsCKu9hRvBA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.0.3",
-        "jest-validate": "^29.0.3",
+        "jest-util": "^29.2.0",
+        "jest-validate": "^29.2.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
@@ -9645,78 +9599,78 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.0.3.tgz",
-      "integrity": "sha512-KzuBnXqNvbuCdoJpv8EanbIGObk7vUBNt/PwQPPx2aMhlv/jaXpUJsqWYRpP/0a50faMBY7WFFP8S3/CCzwfDw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.2.0.tgz",
+      "integrity": "sha512-Cd0Z39sDntEnfR9PoUdFHUAGDvtKI0/7Wt73l3lt03A3yQ+A6Qi3XmBuqGjdFl2QbXaPa937oLhilG612P8HGQ==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^29.0.0",
-        "jest-snapshot": "^29.0.3"
+        "jest-regex-util": "^29.2.0",
+        "jest-snapshot": "^29.2.0"
       }
     },
     "jest-runner": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.0.3.tgz",
-      "integrity": "sha512-Usu6VlTOZlCZoNuh3b2Tv/yzDpKqtiNAetG9t3kJuHfUyVMNW7ipCCJOUojzKkjPoaN7Bl1f7Buu6PE0sGpQxw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.2.0.tgz",
+      "integrity": "sha512-VPBrCwl9fM2mc5yk6yZhNrgXzRJMD5jfLmntkMLlrVq4hQPWbRK998iJlR+DOGCO04TC9PPYLntOJ001Vnf28g==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.0.3",
-        "@jest/environment": "^29.0.3",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/console": "^29.2.0",
+        "@jest/environment": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.10.2",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.0.0",
-        "jest-environment-node": "^29.0.3",
-        "jest-haste-map": "^29.0.3",
-        "jest-leak-detector": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-resolve": "^29.0.3",
-        "jest-runtime": "^29.0.3",
-        "jest-util": "^29.0.3",
-        "jest-watcher": "^29.0.3",
-        "jest-worker": "^29.0.3",
+        "jest-docblock": "^29.2.0",
+        "jest-environment-node": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-leak-detector": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-runtime": "^29.2.0",
+        "jest-util": "^29.2.0",
+        "jest-watcher": "^29.2.0",
+        "jest-worker": "^29.2.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       }
     },
     "jest-runtime": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.0.3.tgz",
-      "integrity": "sha512-12gZXRQ7ozEeEHKTY45a+YLqzNDR/x4c//X6AqwKwKJPpWM8FY4vwn4VQJOcLRS3Nd1fWwgP7LU4SoynhuUMHQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.2.0.tgz",
+      "integrity": "sha512-+GDmzCrswQF+mvI0upTYMe/OPYnlRRNLLDHM9AFLp2y7zxWoDoYgb8DL3WwJ8d9m743AzrnvBV9JQHi/0ed7dg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.0.3",
-        "@jest/fake-timers": "^29.0.3",
-        "@jest/globals": "^29.0.3",
-        "@jest/source-map": "^29.0.0",
-        "@jest/test-result": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/environment": "^29.2.0",
+        "@jest/fake-timers": "^29.2.0",
+        "@jest/globals": "^29.2.0",
+        "@jest/source-map": "^29.2.0",
+        "@jest/test-result": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-mock": "^29.0.3",
-        "jest-regex-util": "^29.0.0",
-        "jest-resolve": "^29.0.3",
-        "jest-snapshot": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-haste-map": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-mock": "^29.2.0",
+        "jest-regex-util": "^29.2.0",
+        "jest-resolve": "^29.2.0",
+        "jest-snapshot": "^29.2.0",
+        "jest-util": "^29.2.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       }
     },
     "jest-snapshot": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.0.3.tgz",
-      "integrity": "sha512-52q6JChm04U3deq+mkQ7R/7uy7YyfVIrebMi6ZkBoDJ85yEjm/sJwdr1P0LOIEHmpyLlXrxy3QP0Zf5J2kj0ew==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.2.0.tgz",
+      "integrity": "sha512-YCKrOR0PLRXROmww73fHO9oeY4tL+LPQXWR3yml1+hKbQDR8j1VUrVzB65hKSJJgxBOr1vWx+hmz2by8JjAU5w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -9725,30 +9679,30 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.0.3",
-        "@jest/transform": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/expect-utils": "^29.2.0",
+        "@jest/transform": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.0.3",
+        "expect": "^29.2.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.0.3",
-        "jest-get-type": "^29.0.0",
-        "jest-haste-map": "^29.0.3",
-        "jest-matcher-utils": "^29.0.3",
-        "jest-message-util": "^29.0.3",
-        "jest-util": "^29.0.3",
+        "jest-diff": "^29.2.0",
+        "jest-get-type": "^29.2.0",
+        "jest-haste-map": "^29.2.0",
+        "jest-matcher-utils": "^29.2.0",
+        "jest-message-util": "^29.2.0",
+        "jest-util": "^29.2.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.0.3",
+        "pretty-format": "^29.2.0",
         "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9757,12 +9711,12 @@
       }
     },
     "jest-util": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.3.tgz",
-      "integrity": "sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.0.tgz",
+      "integrity": "sha512-8M1dx12ujkBbnhwytrezWY0Ut79hbflwodE+qZKjxSRz5qt4xDp6dQQJaOCFvCmE0QJqp9KyEK33lpPNjnhevw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -9771,17 +9725,17 @@
       }
     },
     "jest-validate": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.0.3.tgz",
-      "integrity": "sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.2.0.tgz",
+      "integrity": "sha512-4Vl51bPNeFeDok9aJiOnrC6tqJbOp4iMCYlewoC2ZzYJZ5+6pfr3KObAdx5wP8auHcg2MRaguiqj5OdScZa72g==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.0.3",
+        "@jest/types": "^29.2.0",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.0.0",
+        "jest-get-type": "^29.2.0",
         "leven": "^3.1.0",
-        "pretty-format": "^29.0.3"
+        "pretty-format": "^29.2.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9793,28 +9747,29 @@
       }
     },
     "jest-watcher": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.0.3.tgz",
-      "integrity": "sha512-tQX9lU91A+9tyUQKUMp0Ns8xAcdhC9fo73eqA3LFxP2bSgiF49TNcc+vf3qgGYYK9qRjFpXW9+4RgF/mbxyOOw==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.2.0.tgz",
+      "integrity": "sha512-bRh0JdUeN+cl9XfK7tMnXLm4Mv70hG2SZlqbkFe5CTs7oeCkbwlGBk/mEfEJ63mrxZ8LPbnfaMpfSmkhEQBEGA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.0.3",
-        "@jest/types": "^29.0.3",
+        "@jest/test-result": "^29.2.0",
+        "@jest/types": "^29.2.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.10.2",
-        "jest-util": "^29.0.3",
+        "jest-util": "^29.2.0",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.3.tgz",
-      "integrity": "sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.0.tgz",
+      "integrity": "sha512-mluOlMbRX1H59vGVzPcVg2ALfCausbBpxC8a2KWOzInhYHZibbHH8CB0C1JkmkpfurrkOYgF7FPmypuom1OM9A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
+        "jest-util": "^29.2.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -9831,9 +9786,9 @@
       }
     },
     "js-sdsl": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
-      "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "js-tokens": {
@@ -10022,9 +9977,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -10091,17 +10046,17 @@
       }
     },
     "node-abi": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
-      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
+      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10391,9 +10346,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
-      "integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true
     },
     "portfinder": {
@@ -10455,9 +10410,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "29.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.0.3.tgz",
-      "integrity": "sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.2.0.tgz",
+      "integrity": "sha512-QCSUFdwOi924g24czhOH5eTkXxUCqlLGZBRCySlwDYHIXRJkdGyjJc9nZaqhlFBZws8dq5Dvk0lCilsmlfsPxw==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^29.0.0",
@@ -10722,9 +10677,9 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.0.tgz",
-      "integrity": "sha512-ft96f8WzGxavg0rkLpMw90MTPMUZDyf0tHjPPh8Ob59xt6KzX8EqtotcqZGUm7kwqpX2pmYiyYX2LL0IZ/FDEw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "requires": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",
@@ -10737,9 +10692,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -10988,16 +10943,6 @@
         "has-flag": "^4.0.0"
       }
     },
-    "supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      }
-    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -11025,16 +10970,6 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
-      }
-    },
-    "terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
       }
     },
     "test-exclude": {
@@ -11111,9 +11046,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -11137,9 +11072,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",
@@ -11268,12 +11203,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-image-export-optimizer",
-  "version": "0.16.0",
+  "version": "0.16.1-beta-1",
   "description": "Optimizes all static images for Next.js static HTML export functionality",
   "main": "dist/ExportedImage.js",
   "types": "dist/ExportedImage.d.ts",
@@ -8,12 +8,17 @@
   "engines": {
     "node": ">=16.0.0"
   },
+  "exports": {
+    ".": "./dist/ExportedImage.js",
+    "./future/ExportedImage": "./dist/future/ExportedImage.js"
+  },
   "scripts": {
-    "build": "tsc && npx swc ./src/ExportedImage.tsx -o ./dist/ExportedImage.js",
+    "build": "tsc && npx swc ./src/ExportedImage.tsx -o ./dist/ExportedImage.js && npx swc ./src/future/ExportedImage.tsx -o ./dist/future/ExportedImage.js",
     "test": "jest",
+    "testFileContent": "node ./fileComparison.js",
     "test:e2e": "npx playwright install && playwright test",
     "exportExample": "cd example && npm run export && cd ..",
-    "prepublishOnly": "npm run build && npm test && npm run test:e2e",
+    "prepublishOnly": "npm run testFileContent && npm run build && npm test && npm run test:e2e",
     "fetchTags": "git fetch --tags -f"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-image-export-optimizer",
-  "version": "0.16.1-beta-1",
+  "version": "0.17.0",
   "description": "Optimizes all static images for Next.js static HTML export functionality",
   "main": "dist/ExportedImage.js",
   "types": "dist/ExportedImage.d.ts",

--- a/src/ExportedImage.tsx
+++ b/src/ExportedImage.tsx
@@ -1,6 +1,5 @@
-import Image from "next/image";
 import React, { useMemo, useState } from "react";
-import { ImageProps, StaticImageData } from "next/image";
+import Image, { ImageProps, StaticImageData } from "next/image";
 
 const splitFilePath = ({ filePath }: { filePath: string }) => {
   const filenameWithExtension =

--- a/src/future/ExportedImage.tsx
+++ b/src/future/ExportedImage.tsx
@@ -1,6 +1,5 @@
-import Image from "next/future/image";
 import React, { useMemo, useState } from "react";
-import { ImageProps, StaticImageData } from "next/future/image";
+import Image, { ImageProps, StaticImageData } from "next/future/image";
 
 const splitFilePath = ({ filePath }: { filePath: string }) => {
   const filenameWithExtension =
@@ -133,7 +132,6 @@ function ExportedImage({
           filter: "url(#sharpBlur)",
         }
       : undefined;
-  console.log(blurStyle);
 
   const ImageElement = (
     <Image
@@ -197,7 +195,11 @@ function ExportedImage({
           {...(unoptimized && { unoptimized })}
           {...(priority && { priority })}
           style={style}
-          loader={fallbackLoader}
+          loader={
+            imageError || unoptimized === true
+              ? fallbackLoader
+              : (e) => optimizedLoader({ src, width: e.width, useWebp })
+          }
           src={typeof src === "object" ? src.src : src}
         />
       </noscript>

--- a/src/optimizeImages.js
+++ b/src/optimizeImages.js
@@ -241,6 +241,8 @@ const nextImageExportOptimizer = async function () {
   let sizeOfGeneratedImages = 0;
   const allGeneratedImages = [];
 
+  const updatedImageHashes = {};
+
   // Loop through all images
   for (let index = 0; index < allImagesInImageFolder.length; index++) {
     const file = allImagesInImageFolder[index].file;
@@ -258,13 +260,14 @@ const nextImageExportOptimizer = async function () {
       fileDirectory,
       file,
     ]);
+    const keyForImageHashes = `${fileDirectory}/${file}`;
 
     let hashContentChanged = false;
-    if (imageHashes[file] !== imageHash) {
+    if (imageHashes[keyForImageHashes] !== imageHash) {
       hashContentChanged = true;
     }
     // Store image hash in temporary object
-    imageHashes[file] = imageHash;
+    updatedImageHashes[keyForImageHashes] = imageHash;
 
     let optimizedOriginalWidthImagePath;
     let optimizedOriginalWidthImageSizeInMegabytes;
@@ -294,7 +297,7 @@ const nextImageExportOptimizer = async function () {
       // opt file directory
       if (
         !hashContentChanged &&
-        file in imageHashes &&
+        keyForImageHashes in imageHashes &&
         fs.existsSync(optimizedFileNameAndPath)
       ) {
         const stats = fs.statSync(optimizedFileNameAndPath);
@@ -378,7 +381,7 @@ const nextImageExportOptimizer = async function () {
       }
     }
   }
-  let data = JSON.stringify(imageHashes, null, 4);
+  let data = JSON.stringify(updatedImageHashes, null, 4);
   fs.writeFileSync(hashFilePath, data);
 
   // Copy the optimized images to the build folder

--- a/test/__snapshots__/optimizeImages.test.js.snap
+++ b/test/__snapshots__/optimizeImages.test.js.snap
@@ -41,6 +41,23 @@ exports[`legacyConfig 1`] = `
 
 exports[`legacyConfig 2`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.WEBP",
@@ -124,6 +141,23 @@ exports[`legacyConfig 4`] = `
 
 exports[`legacyConfig 5`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.WEBP",
@@ -440,6 +474,91 @@ exports[`legacyConfig 9`] = `
   ],
   [
     "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    128,
+    85,
+  ],
+  [
+    "webp",
+    16,
+    11,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    256,
+    171,
+  ],
+  [
+    "webp",
+    32,
+    21,
+  ],
+  [
+    "webp",
+    384,
+    256,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    48,
+    32,
+  ],
+  [
+    "webp",
+    64,
+    43,
+  ],
+  [
+    "webp",
+    640,
+    427,
+  ],
+  [
+    "webp",
+    750,
+    500,
+  ],
+  [
+    "webp",
+    828,
+    552,
+  ],
+  [
+    "webp",
+    96,
+    64,
+  ],
+  [
+    "webp",
+    10,
+    7,
+  ],
+  [
+    "webp",
     1080,
     720,
   ],
@@ -562,6 +681,23 @@ exports[`newConfig 1`] = `
 
 exports[`newConfig 2`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.WEBP",
@@ -645,6 +781,23 @@ exports[`newConfig 4`] = `
 
 exports[`newConfig 5`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.WEBP",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.WEBP",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.WEBP",
@@ -961,6 +1114,91 @@ exports[`newConfig 9`] = `
   ],
   [
     "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    128,
+    85,
+  ],
+  [
+    "webp",
+    16,
+    11,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    256,
+    171,
+  ],
+  [
+    "webp",
+    32,
+    21,
+  ],
+  [
+    "webp",
+    384,
+    256,
+  ],
+  [
+    "webp",
+    900,
+    600,
+  ],
+  [
+    "webp",
+    48,
+    32,
+  ],
+  [
+    "webp",
+    64,
+    43,
+  ],
+  [
+    "webp",
+    640,
+    427,
+  ],
+  [
+    "webp",
+    750,
+    500,
+  ],
+  [
+    "webp",
+    828,
+    552,
+  ],
+  [
+    "webp",
+    96,
+    64,
+  ],
+  [
+    "webp",
+    10,
+    7,
+  ],
+  [
+    "webp",
     1080,
     720,
   ],
@@ -1083,6 +1321,23 @@ exports[`newConfigJpeg 1`] = `
 
 exports[`newConfigJpeg 2`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.JPG",
@@ -1166,6 +1421,23 @@ exports[`newConfigJpeg 4`] = `
 
 exports[`newConfigJpeg 5`] = `
 [
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-10.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1080.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1200.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-128.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-16.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-1920.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-2048.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-256.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-32.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-384.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-3840.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-48.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-64.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-640.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-750.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-828.JPG",
+  "chris-zhang-Jq8-3Bmh1pQ-unsplash_small.0fa13b23-opt-96.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-10.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1080.JPG",
   "chris-zhang-Jq8-3Bmh1pQ-unsplash_static.921260e0-opt-1200.JPG",
@@ -1475,6 +1747,91 @@ exports[`newConfigJpeg 8`] = `
 
 exports[`newConfigJpeg 9`] = `
 [
+  [
+    "jpeg",
+    10,
+    7,
+  ],
+  [
+    "jpeg",
+    900,
+    600,
+  ],
+  [
+    "jpeg",
+    900,
+    600,
+  ],
+  [
+    "jpeg",
+    128,
+    85,
+  ],
+  [
+    "jpeg",
+    16,
+    11,
+  ],
+  [
+    "jpeg",
+    900,
+    600,
+  ],
+  [
+    "jpeg",
+    900,
+    600,
+  ],
+  [
+    "jpeg",
+    256,
+    171,
+  ],
+  [
+    "jpeg",
+    32,
+    21,
+  ],
+  [
+    "jpeg",
+    384,
+    256,
+  ],
+  [
+    "jpeg",
+    900,
+    600,
+  ],
+  [
+    "jpeg",
+    48,
+    32,
+  ],
+  [
+    "jpeg",
+    64,
+    43,
+  ],
+  [
+    "jpeg",
+    640,
+    427,
+  ],
+  [
+    "jpeg",
+    750,
+    500,
+  ],
+  [
+    "jpeg",
+    828,
+    552,
+  ],
+  [
+    "jpeg",
+    96,
+    64,
+  ],
   [
     "jpeg",
     10,


### PR DESCRIPTION
- Use the next/image/future Image component by importing

    import ExportedImageFuture from "next-image-export-optimizer/future/ExportedImage";

- Fix hash conflict of images that have the same name but are in different folders by using the path/image as the key instead of only the file name of the image
- Clear hash file of old hash entries every time the next-image-export-optimizer is running
