### PR TITLE
Avoid duplication for static images

### DIFF
--- a/src/optimizeImages.js
+++ b/src/optimizeImages.js
@@ -240,6 +240,10 @@ const nextImageExportOptimizer = async function () {
       newPath?.nextImageExportOptimizer_imageFolderPath !== undefined
     ) {
       imageFolderPath = newPath.nextImageExportOptimizer_imageFolderPath;
+      // if the imageFolderPath starts with a slash, remove it
+      if (imageFolderPath.startsWith("/")) {
+        imageFolderPath = imageFolderPath.slice(1);
+      }
     }
     if (legacyPath?.exportFolderPath !== undefined) {
       exportFolderPath = legacyPath.exportFolderPath;
@@ -316,17 +320,6 @@ const nextImageExportOptimizer = async function () {
     );
   }
 
-  // Create the folder for the optimized images if it does not exists
-  const folderNameForOptImages = `${imageFolderPath}/${exportFolderName}`;
-  try {
-    if (!fs.existsSync(folderNameForOptImages)) {
-      fs.mkdirSync(folderNameForOptImages);
-      console.log(`Create image output folder: ${folderNameForOptImages}`);
-    }
-  } catch (err) {
-    console.error(err);
-  }
-
   // Create the folder for the remote images if it does not exists
   if (remoteImageURLs.length > 0) {
     try {
@@ -388,11 +381,17 @@ const nextImageExportOptimizer = async function () {
     // No image hashes yet
   }
 
-  const allFilesInImageFolderAndSubdirectories = getAllFiles(
-    imageFolderPath,
-    imageFolderPath,
-    exportFolderName
-  );
+  // check if the image folder is a subdirectory of the public folder
+  // if not, the images in the image folder can only be static images and are taken from the static image folder (staticImageFolderPath)
+  // so we do not add them to the images that need to be optimized
+
+  const isImageFolderSubdirectoryOfPublicFolder =
+    imageFolderPath.includes("public");
+
+  const allFilesInImageFolderAndSubdirectories =
+    isImageFolderSubdirectoryOfPublicFolder
+      ? getAllFiles(imageFolderPath, imageFolderPath, exportFolderName)
+      : [];
   const allFilesInStaticImageFolder = getAllFiles(
     staticImageFolderPath,
     staticImageFolderPath,


### PR DESCRIPTION
If the nextImageExportOptimizer_imageFolderPath is not a subdirectory of the public folder, they only contain static images. We use the static images found in .next/static/media, so we don't have to optimize and store the images in the imageFolderPath. Saves some duplicates of images in the project directory.