### PR TITLE
Added ability to load remote images from promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ module.exports = {
    />;
    ```
 
-   In order for the image optimization at build time to work correctly, you have to specify all remote image urls in a file called **remoteOptimizedImages.js** in the root directory of your project (where the next.config.js is stored as well). The file should export an array of strings containing the urls of the remote images.
+   In order for the image optimization at build time to work correctly, you have to specify all remote image urls in a file called **remoteOptimizedImages.js** in the root directory of your project (where the next.config.js is stored as well). The file should export an array of strings containing the urls of the remote images. Returning a promise of such array is also supported.
 
    Example:
 
@@ -154,6 +154,13 @@ module.exports = {
      "https://example.com/image3.jpg",
      // ...
    ];
+   // OR
+   module.exports = new Promise(resolve => resolve([
+     "https://example.com/image1.jpg",
+     "https://example.com/image2.jpg",
+     "https://example.com/image3.jpg",
+     // ...
+   ]));
    ```
 
    At build time, the images will be downloaded each time (as they might have changed) and optimized if an image is not yet in the cache or the image has changes.

--- a/src/optimizeImages.js
+++ b/src/optimizeImages.js
@@ -47,14 +47,6 @@ if (nextConfigPath) {
 }
 const nextConfigFolder = path.dirname(nextConfigPath);
 
-let remoteImageURLs = [];
-const remoteImagesFilePath = path.join(
-  nextConfigFolder,
-  "remoteOptimizedImages.js"
-);
-if (fs.existsSync(remoteImagesFilePath)) {
-  remoteImageURLs = require(remoteImagesFilePath);
-}
 const folderNameForRemoteImages = `remoteImagesForOptimization`;
 const folderPathForRemoteImages = path.join(
   nextConfigFolder,
@@ -78,35 +70,46 @@ function urlToFilename(url) {
   return filename;
 }
 
-// Create the filenames for the remote images
-const remoteImageFilenames = remoteImageURLs.map((url) => {
-  const extension = url.split(".").pop();
-  // If the extension is not supported, then we log an error
-  if (
-    !extension ||
-    !["JPG", "JPEG", "WEBP", "PNG", "GIF", "AVIF"].includes(
-      extension.toUpperCase()
-    )
-  ) {
-    console.error(
-      `The image ${url} has an unsupported extension. Please use JPG, JPEG, WEBP, PNG, GIF or AVIF.`
-    );
-    return;
-  }
-  const encodedURL = urlToFilename(url);
-
-  const filename = path.join(
-    folderPathForRemoteImages,
-    `${encodedURL}.${extension}`
+async function getRemoteImageURLs() {
+  let remoteImageURLs = [];
+  const remoteImagesFilePath = path.join(
+    nextConfigFolder,
+    "remoteOptimizedImages.js"
   );
+  if (fs.existsSync(remoteImagesFilePath)) {
+    remoteImageURLs = Promise.resolve(require(remoteImagesFilePath));
+  }
+  // Create the filenames for the remote images
+  const remoteImageFilenames = remoteImageURLs.map((url) => {
+    const extension = url.split(".").pop();
+    // If the extension is not supported, then we log an error
+    if (
+      !extension ||
+      !["JPG", "JPEG", "WEBP", "PNG", "GIF", "AVIF"].includes(
+        extension.toUpperCase()
+      )
+    ) {
+      console.error(
+        `The image ${url} has an unsupported extension. Please use JPG, JPEG, WEBP, PNG, GIF or AVIF.`
+      );
+      return;
+    }
+    const encodedURL = urlToFilename(url);
 
-  return {
-    basePath: folderPathForRemoteImages,
-    file: `${encodedURL}.${extension}`,
-    dirPathWithoutBasePath: "",
-    fullPath: filename,
-  };
-});
+    const filename = path.join(
+      folderPathForRemoteImages,
+      `${encodedURL}.${extension}`
+    );
+
+    return {
+      basePath: folderPathForRemoteImages,
+      file: `${encodedURL}.${extension}`,
+      dirPathWithoutBasePath: "",
+      fullPath: filename,
+    };
+  });
+  return { remoteImageFilenames, remoteImageURLs };
+}
 
 if (exportFolderPathCommandLine) {
   exportFolderPathCommandLine = path.isAbsolute(exportFolderPathCommandLine)
@@ -231,6 +234,7 @@ const nextImageExportOptimizer = async function () {
   let storePicturesInWEBP = true;
   let blurSize = [];
   let exportFolderName = "nextImageExportOptimizer";
+  const { remoteImageFilenames, remoteImageURLs } = await getRemoteImageURLs();
   try {
     // Read in the configuration parameters
     const nextjsConfig = await loadConfig("phase-export", nextConfigFolder);

--- a/src/optimizeImages.js
+++ b/src/optimizeImages.js
@@ -77,7 +77,7 @@ async function getRemoteImageURLs() {
     "remoteOptimizedImages.js"
   );
   if (fs.existsSync(remoteImagesFilePath)) {
-    remoteImageURLs = Promise.resolve(require(remoteImagesFilePath));
+    remoteImageURLs = await Promise.resolve(require(remoteImagesFilePath));
   }
   // Create the filenames for the remote images
   const remoteImageFilenames = remoteImageURLs.map((url) => {


### PR DESCRIPTION
I was unable to run the tests though. Do you actually build this in CI somewhere? What is the reusable way to develop? I tried just yarn install and test but it kept complaining. 

I think there might be some dev dependencies missing. If you let me know how you do this, I can add it to the readme.

TLDR of the work here:
I just refactored some of the functionality into an async function called getRemoteImageURLs which returns both remoteImageURLs and remoteImageFilenames in a similar fashion it used to before. This function is then used inside the main plugin function. 