### PR TITLE
Split content-type at plus sign, e.g. image/svg+xml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+example/.next
+example/out
+example/public
+*.css
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/src/utils/downloadImagesInBatches.ts
+++ b/src/utils/downloadImagesInBatches.ts
@@ -34,7 +34,7 @@ async function downloadImage(url: string, filename: string, folder: string) {
       if (imageFormat.includes(";")) {
         imageFormat = imageFormat.split(";")[0];
       }
-      
+
       // Further split on plus (+) if exists, e.g. image/svg+xml
       if (imageFormat.includes("+")) {
         imageFormat = imageFormat.split("+")[0];

--- a/src/utils/downloadImagesInBatches.ts
+++ b/src/utils/downloadImagesInBatches.ts
@@ -34,6 +34,11 @@ async function downloadImage(url: string, filename: string, folder: string) {
       if (imageFormat.includes(";")) {
         imageFormat = imageFormat.split(";")[0];
       }
+      
+      // Further split on plus (+) if exists, e.g. image/svg+xml
+      if (imageFormat.includes("+")) {
+        imageFormat = imageFormat.split("+")[0];
+      }
 
       // Check for jpeg and change it to jpg if necessary
       if (imageFormat === "jpeg") {


### PR DESCRIPTION
This commit allows to also download remote SVG images using next-image-export-optimizer.

This is kindly related to #169, which covers another edge case with content-type processing of remote images.