### PR TITLE
Update readme for static imports and export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,21 +116,20 @@ module.exports = {
      height={500}
    />;
    ```
-
+   **static import:**  
    The static import method is recommended as it informs the client about the original image size. For image sizes larger than the original width, the next largest image size in the deviceSizes array (specified in the next.config.js) will be used for the generation of the srcset attribute.  
 
-   For static Import it is important placing the images inside your "src" folder instead of "public" folder. Adjust the `nextImageExportOptimizer_imageFolderPath` in the `next.config.js` accordingling.
- 
-```javascript
-module.exports = {
-...
-  env: {
-  nextImageExportOptimizer_imageFolderPath: "src/images"
-  ...
-  }
- }
- ```
-
+   For static Import it is important placing the images somewhere within the "src" folder. Adjust the `nextImageExportOptimizer_imageFolderPath` in the `next.config.js` accordingling.
+   ```javascript
+    module.exports = {
+      ...
+      env: {
+        nextImageExportOptimizer_imageFolderPath: "src/images"
+        ...
+     }
+    }
+   ```
+   **dynamic import:**  
    For the dynamic import method, this library will create duplicates of the original image for each image size in the deviceSizes array that is larger than the original image size.
 
 6. In the development mode, either the original image will be served as a fallback when the optimized images are not yet generated or the optimized image once the image transformation was executed for the specific image. The optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser.

--- a/README.md
+++ b/README.md
@@ -117,13 +117,25 @@ module.exports = {
    />;
    ```
 
-   The static import method is recommended as it informs the client about the original image size. For image sizes larger than the original width, the next largest image size in the deviceSizes array (specified in the next.config.js) will be used for the generation of the srcset attribute.
+   The static import method is recommended as it informs the client about the original image size. For image sizes larger than the original width, the next largest image size in the deviceSizes array (specified in the next.config.js) will be used for the generation of the srcset attribute.  
+
+   For static Import it is important placing the images inside your "src" folder instead of "public" folder. Adjust the `nextImageExportOptimizer_imageFolderPath` in the `next.config.js` accordingling.
+ 
+```javascript
+module.exports = {
+...
+  env: {
+  nextImageExportOptimizer_imageFolderPath: "src/images"
+  ...
+  }
+ }
+ ```
 
    For the dynamic import method, this library will create duplicates of the original image for each image size in the deviceSizes array that is larger than the original image size.
 
-5. In the development mode, either the original image will be served as a fallback when the optimized images are not yet generated or the optimized image once the image transformation was executed for the specific image. The optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser.
+6. In the development mode, either the original image will be served as a fallback when the optimized images are not yet generated or the optimized image once the image transformation was executed for the specific image. The optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser.
 
-6. This library also supports remote images. You have to specify the src as a string starting with either http or https in the ExportedImage component.
+7. This library also supports remote images. You have to specify the src as a string starting with either http or https in the ExportedImage component.
 
    ```javascript
    import ExportedImage from "next-image-export-optimizer";
@@ -182,7 +194,7 @@ module.exports = {
    - 2592000 for 1 month
    - 31536000 for 1 year
 
-7. You can output the original, unoptimized images using the `unoptimized` prop.
+8. You can output the original, unoptimized images using the `unoptimized` prop.
    Example:
 
    ```javascript
@@ -195,7 +207,7 @@ module.exports = {
    />;
    ```
 
-8. Overriding presets in **next.config.js**:
+9. Overriding presets in **next.config.js**:
 
    **Placeholder images:**
    If you do not want the automatic generation of tiny, blurry placeholder images, set the `nextImageExportOptimizer_generateAndUseBlurImages` environment variable to `false` and set the `placeholder` prop from the **\<ExportedImage />** component to `empty`.
@@ -206,7 +218,7 @@ module.exports = {
    **Rename the export folder name:**
    If you want to rename the export folder name, set the `nextImageExportOptimizer_exportFolderPath` environment variable to the desired folder name. The default is `nextImageExportOptimizer`.
 
-9. You can still use the legacy image component `next/legacy/image`:
+10. You can still use the legacy image component `next/legacy/image`:
 
    ```javascript
    import ExportedImage from "next-image-export-optimizer/legacy/ExportedImage";
@@ -216,7 +228,7 @@ module.exports = {
    <ExportedImage src={testPictureStatic} alt="Static Image" layout="fixed" />;
    ```
 
-10. BasePath:
+11. BasePath:
     You can set the basePath in the next.config.js file. This is useful if you want to deploy your app to a subfolder of your domain.
 
     ```javascript
@@ -238,7 +250,7 @@ module.exports = {
     />;
     ```
 
-11. Animated images:
+12. Animated images:
     You can use .gif and animated .webp images. Next-image-export-optimizer will automatically optimize the animated images and generate the srcset for the different resolutions.
 
     If you set the variable nextImageExportOptimizer_storePicturesInWEBP to true, the animated images will be converted to .webp format which can reduce the file size significantly.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configure the library in your **Next.js** configuration file:
 ```javascript
 // next.config.js
 module.exports = {
+  output: "export", // use nextjs static export
   images: {
     loader: "custom",
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
@@ -65,21 +66,21 @@ module.exports = {
 
    ```diff
    {
-   -  "export": "next build && next export",
-   +  "export": "next build && next export && next-image-export-optimizer"
+   -  "export": "next build",
+   +  "export": "next build && next-image-export-optimizer"
    }
    ```
 
    If your Next.js project is not at the root directory where you are running the commands, for example if you are using a monorepo, you can specify the location of the next.config.js as an argument to the script:
 
    ```json
-   "export": "next build && next export && next-image-export-optimizer --nextConfigPath path/to/my/next.config.js"
+   "export": "next build && next-image-export-optimizer --nextConfigPath path/to/my/next.config.js"
    ```
 
    If you want to specify the path to the output folder, you can either do so by setting the `nextImageExportOptimizer_exportFolderPath` environment variable in your **next.config.js** file or by passing the `--exportFolderPath` argument to the script:
 
    ```json
-    "export": "next build && next export && next-image-export-optimizer --exportFolderPath path/to/my/export/folder"
+    "export": "next build && next-image-export-optimizer --exportFolderPath path/to/my/export/folder"
    ```
 
 4. Change the **\<Image />** component to the **\<ExportedImage />** component of this library.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ module.exports = {
 4. Change the **\<Image />** component to the **\<ExportedImage />** component of this library.
 
    Example:
-
    ```javascript
    // Old
    import Image from "next/image";
@@ -132,9 +131,9 @@ module.exports = {
    **dynamic import:**  
    For the dynamic import method, this library will create duplicates of the original image for each image size in the deviceSizes array that is larger than the original image size.
 
-6. In the development mode, either the original image will be served as a fallback when the optimized images are not yet generated or the optimized image once the image transformation was executed for the specific image. The optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser.
+5. In the development mode, either the original image will be served as a fallback when the optimized images are not yet generated or the optimized image once the image transformation was executed for the specific image. The optimized images are created at build time only. In the exported, static React app, the responsive images are available as srcset and dynamically loaded by the browser.
 
-7. This library also supports remote images. You have to specify the src as a string starting with either http or https in the ExportedImage component.
+6. This library also supports remote images. You have to specify the src as a string starting with either http or https in the ExportedImage component.
 
    ```javascript
    import ExportedImage from "next-image-export-optimizer";
@@ -193,7 +192,7 @@ module.exports = {
    - 2592000 for 1 month
    - 31536000 for 1 year
 
-8. You can output the original, unoptimized images using the `unoptimized` prop.
+7. You can output the original, unoptimized images using the `unoptimized` prop.
    Example:
 
    ```javascript
@@ -206,7 +205,7 @@ module.exports = {
    />;
    ```
 
-9. Overriding presets in **next.config.js**:
+8. Overriding presets in **next.config.js**:
 
    **Placeholder images:**
    If you do not want the automatic generation of tiny, blurry placeholder images, set the `nextImageExportOptimizer_generateAndUseBlurImages` environment variable to `false` and set the `placeholder` prop from the **\<ExportedImage />** component to `empty`.
@@ -217,7 +216,7 @@ module.exports = {
    **Rename the export folder name:**
    If you want to rename the export folder name, set the `nextImageExportOptimizer_exportFolderPath` environment variable to the desired folder name. The default is `nextImageExportOptimizer`.
 
-10. You can still use the legacy image component `next/legacy/image`:
+9. You can still use the legacy image component `next/legacy/image`:
 
    ```javascript
    import ExportedImage from "next-image-export-optimizer/legacy/ExportedImage";
@@ -227,7 +226,8 @@ module.exports = {
    <ExportedImage src={testPictureStatic} alt="Static Image" layout="fixed" />;
    ```
 
-11. BasePath:
+
+10. BasePath:
     You can set the basePath in the next.config.js file. This is useful if you want to deploy your app to a subfolder of your domain.
 
     ```javascript
@@ -249,7 +249,7 @@ module.exports = {
     />;
     ```
 
-12. Animated images:
+11. Animated images:
     You can use .gif and animated .webp images. Next-image-export-optimizer will automatically optimize the animated images and generate the srcset for the different resolutions.
 
     If you set the variable nextImageExportOptimizer_storePicturesInWEBP to true, the animated images will be converted to .webp format which can reduce the file size significantly.


### PR DESCRIPTION
1. some little updates for the readme in point 4. to prevent getting trapped with static import [;)](https://github.com/Niels-IO/next-image-export-optimizer/issues/198)
2. changed the `export` command according to the nextjs [docs](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) 
<img width="1197" alt="image" src="https://github.com/Niels-IO/next-image-export-optimizer/assets/2795534/efaaa8b5-7907-4385-8cb8-2080e1f5d38f">