### PR TITLE
Updated README with examples for new output: export

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Configure the library in your **Next.js** configuration file:
 ```javascript
 // next.config.js
 module.exports = {
+  // If you're on a newer version of Next, "output: export" is preferred over export command
+  output: 'export',
+   
   images: {
     loader: "custom",
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
@@ -65,10 +68,12 @@ module.exports = {
 
    ```diff
    {
-   -  "export": "next build && next export",
-   +  "export": "next build && next export && next-image-export-optimizer"
+   -  "export": "next build",
+   +  "export": "next build && next-image-export-optimizer"
    }
    ```
+Note: if you use an old version of Next and still use the 'next export' command, keep this command between `next build` & `next-image-export-optimizer`
+
 
    If your Next.js project is not at the root directory where you are running the commands, for example if you are using a monorepo, you can specify the location of the next.config.js as an argument to the script:
 


### PR DESCRIPTION
Hey Niels, goeiemorgen 😉

First of all, amazing plugin it really helped me alot!

Anyway I noticed some lines in the documentation about `next export` which seems like the old way next does static exporting, nowadays they favor a line in the next config: output: export

As seen in the docs here: https://nextjs.org/docs/pages/building-your-application/deploying/static-exports

I have made some very minor changes to the README reflecting this, when following your README and adding the next export command I got the following in my console:
<img width="889" alt="image" src="https://github.com/Niels-IO/next-image-export-optimizer/assets/25297659/59afb112-4fe8-4e77-ada5-29da1f46bcc9">

This is now gone, I am using Next 14.1.0