### PR TITLE
upate copy path to correctly handle files that contain the word public

### DIFF
--- a/src/optimizeImages.ts
+++ b/src/optimizeImages.ts
@@ -501,7 +501,15 @@ const nextImageExportOptimizer = async function () {
     const filePath = allGeneratedImages[index];
     const fileInBuildFolder = path.join(
       exportFolderPath,
-      filePath.split("public").slice(1).join("public")
+      (() => {
+        const parts = filePath.split("public");
+        if (parts.length > 1) {
+          return parts.slice(1).join("public");
+        } else {
+          // Handle case where 'public' is not found
+          return filePath;
+        }
+      })()
     );
 
     // Create the folder for the optimized images in the build directory if it does not exists

--- a/src/optimizeImages.ts
+++ b/src/optimizeImages.ts
@@ -501,7 +501,7 @@ const nextImageExportOptimizer = async function () {
     const filePath = allGeneratedImages[index];
     const fileInBuildFolder = path.join(
       exportFolderPath,
-      filePath.split("public").pop()
+      filePath.split("public").slice(1).join("public")
     );
 
     // Create the folder for the optimized images in the build directory if it does not exists


### PR DESCRIPTION
The copy function isn't working with filenames or paths that contain the word public.
Instead of just taking the part of the path found after the last instance of the word `public` this change will take everything after the first instance found.