### PR TITLE
Handle raw application/octet-stream content-type

### DIFF
--- a/src/utils/downloadImagesInBatches.ts
+++ b/src/utils/downloadImagesInBatches.ts
@@ -56,7 +56,7 @@ async function downloadImage(url: string, filename: string, folder: string) {
       const hasMatchingExtension = regex.test(filename);
 
       // Add appropriate extension to filename based on image format
-      const formattedFilename = hasMatchingExtension
+      const formattedFilename = hasMatchingExtension || imageFormat === 'octet-stream'
         ? filename
         : `${filename}.${imageFormat}`;
 


### PR DESCRIPTION
If an image's `content-type` comes as `application/octet-stream`, it may not include the image format in the header. This change handles the case where the code would assign filenames incorrectly because of that header.