### PR TITLE
Add nextImageExportOptimizer_assetPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Or by passing the argument to the script:
  "export": "next build && next-image-export-optimizer --exportFolderPath path/to/my/export/folder"
 ```
 
+### Serve images from CDN / Prefixing a domain before generated optimized image urls
+
+To append a prefix, usually your CDN, to the generated urls, pass the following setting to your `next.config.js`.
+
+This method assume that you already deploy your generated images to your CDN after images are generated. It will simply append a prefix.
+
+```javascript
+// next.config.js
+{ "env": {
+"nextImageExportOptimizer_assetPrefix": "https://cdn.yourhost.com/"
+}}
+```
+
 ### Base path
 
 If you want to deploy your app to a subfolder of your domain, you can set the basePath in the `next.config.js` file:

--- a/example/environment.d.ts
+++ b/example/environment.d.ts
@@ -7,6 +7,7 @@ declare global {
       nextImageExportOptimizer_generateAndUseBlurImages: string | undefined;
       nextImageExportOptimizer_exportFolderName: string | undefined;
       nextImageExportOptimizer_quality: string | undefined;
+      nextImageExportOptimizer_assetPrefix: string | undefined;
       __NEXT_IMAGE_OPTS: { deviceSizes: string[]; imageSizes: string[] };
     }
   }

--- a/example/src/ExportedImage.tsx
+++ b/example/src/ExportedImage.tsx
@@ -86,11 +86,16 @@ const generateImageURL = (
 
   let generatedImageURL = `${
     isStaticImage ? basePathPrefixForStaticImages : correctedPath
-  }${exportFolderName}/${filename}-opt-${width}.${processedExtension.toUpperCase()}`;
+    }${exportFolderName}/${filename}-opt-${width}.${processedExtension.toUpperCase()}`;
 
   // if the generatedImageURL is not starting with a slash, then we add one as long as it is not a remote image
   if (!isRemoteImage && generatedImageURL.charAt(0) !== "/") {
     generatedImageURL = "/" + generatedImageURL;
+  }
+
+  const assetPrefix = process.env.nextImageExportOptimizer_assetPrefix;
+  if (assetPrefix) {
+    generatedImageURL = assetPrefix + generatedImageURL;
   }
 
   return generatedImageURL;
@@ -268,16 +273,16 @@ const ExportedImage = forwardRef<HTMLImageElement | null, ExportedImageProps>(
     // is expecting a base64 encoded string, but the generated blurDataURL is a normal URL
     const blurStyle =
       placeholder === "blur" &&
-      !isSVG &&
-      automaticallyCalculatedBlurDataURL &&
-      automaticallyCalculatedBlurDataURL.startsWith("/") &&
-      !blurComplete
+        !isSVG &&
+        automaticallyCalculatedBlurDataURL &&
+        automaticallyCalculatedBlurDataURL.startsWith("/") &&
+        !blurComplete
         ? {
-            backgroundSize: style?.objectFit || "cover",
-            backgroundPosition: style?.objectPosition || "50% 50%",
-            backgroundRepeat: "no-repeat",
-            backgroundImage: `url("${automaticallyCalculatedBlurDataURL}")`,
-          }
+          backgroundSize: style?.objectFit || "cover",
+          backgroundPosition: style?.objectPosition || "50% 50%",
+          backgroundRepeat: "no-repeat",
+          backgroundImage: `url("${automaticallyCalculatedBlurDataURL}")`,
+        }
         : undefined;
     const isStaticImage = typeof src === "object";
 
@@ -294,7 +299,7 @@ const ExportedImage = forwardRef<HTMLImageElement | null, ExportedImageProps>(
       return imageError || unoptimized === true
         ? () => fallbackLoader({ src: overrideSrc || src })
         : (e: { width: number }) =>
-            optimizedLoader({ src, width: e.width, basePath });
+          optimizedLoader({ src, width: e.width, basePath });
     }, [imageError, unoptimized, overrideSrc, src, basePath]);
 
     const handleError = useCallback(


### PR DESCRIPTION
This pull request add a setting in `next.config.js` to allow serving image from CDN

```javascript
// next.config.js
{ "env": {
"nextImageExportOptimizer_assetPrefix": "https://cdn.yourhost.com/"
}}
```

It simply append the CDN url to generated image url. The deployment to any cdn should be handle separately.

Apologize for some line space changes due to my editor's linter.

Tested on `next@16.1.6`