### PR TITLE
Fix 404s for AVIF sources when storePicturesInWEBP is enabled

### DIFF
--- a/example/src/ExportedImage.tsx
+++ b/example/src/ExportedImage.tsx
@@ -47,7 +47,7 @@ const generateImageURL = (
 
   if (
     useWebp &&
-    ["JPG", "JPEG", "PNG", "GIF"].includes(extension.toUpperCase())
+    ["JPG", "JPEG", "PNG", "GIF", "AVIF"].includes(extension.toUpperCase())
   ) {
     processedExtension = "WEBP";
   }

--- a/example/src/legacy/ExportedImage.tsx
+++ b/example/src/legacy/ExportedImage.tsx
@@ -46,7 +46,7 @@ const generateImageURL = (
 
   if (
     useWebp &&
-    ["JPG", "JPEG", "PNG", "GIF"].includes(extension.toUpperCase())
+    ["JPG", "JPEG", "PNG", "GIF", "AVIF"].includes(extension.toUpperCase())
   ) {
     processedExtension = "WEBP";
   }


### PR DESCRIPTION
Fixes #263

## Problem

When the source image is `.avif` and `nextImageExportOptimizer_storePicturesInWEBP` is enabled (the default), the optimizer and the component disagree about the output extension:

- `optimizeImages.ts` rewrites the extension to `WEBP` for **every** supported input when `storePicturesInWEBP` is set — including AVIF — so only `photo-opt-<width>.WEBP` files are written to disk.
- `ExportedImage` (and the legacy variant) excludes `AVIF` from its extension-substitution list, so the generated `srcset` keeps `.AVIF` paths.

Result: every optimized variant of an AVIF source 404s in production.

## Fix

Add `"AVIF"` to the substitution list in `example/src/ExportedImage.tsx` and `example/src/legacy/ExportedImage.tsx`, matching what the optimizer writes. Behavior with `storePicturesInWEBP=false` is unchanged (extension stays `AVIF`, which matches the `.AVIF` files the optimizer writes in that mode).

## Verification

Rendered `ExportedImage` with `src="/images/photo.avif"` and `storePicturesInWEBP=true` via `react-dom/server` against the built package:

**Before:**
```
srcset: /images/nextImageExportOptimizer/photo-opt-1200.AVIF 1x, /images/nextImageExportOptimizer/photo-opt-3840.AVIF 2x
```

**After:**
```
srcset: /images/nextImageExportOptimizer/photo-opt-1200.WEBP 1x, /images/nextImageExportOptimizer/photo-opt-3840.WEBP 2x
```

- `npm run build` passes
- `npm test` passes (5 tests, 42 snapshots)